### PR TITLE
Reformat Model Class

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.napoleon",
 ]
 
+napoleon_use_rtype = True
 napoleon_google_docstring = False
 
 doctest_global_setup = """

--- a/docs/source/pybamm.models.rst
+++ b/docs/source/pybamm.models.rst
@@ -19,6 +19,14 @@ pybamm.models.core module
     :undoc-members:
     :show-inheritance:
 
+pybamm.models.electrolyte\_current module
+-----------------------------------------
+
+.. automodule:: pybamm.models.electrolyte_current
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 pybamm.models.reaction\_diffusion module
 ----------------------------------------
 

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -91,6 +91,7 @@ from .models.reaction_diffusion import ReactionDiffusionModel
 # Component classes
 #
 from .models.components.electrolyte import Electrolyte
+from .models.components.interface import Interface
 
 #
 # Remove any imported modules, so we don't expose them as part of pybamm

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -86,6 +86,7 @@ from .variables import Variables
 #
 from .models.core import BaseModel
 from .models.reaction_diffusion import ReactionDiffusionModel
+from .models.electrolyte_current import ElectrolyteCurrentModel
 
 #
 # Component classes

--- a/pybamm/models/components/electrolyte.py
+++ b/pybamm/models/components/electrolyte.py
@@ -16,11 +16,11 @@ class Electrolyte(object):
 
         Parameters
         ----------
-        param : :class:`pybamm.Parameters` instance
+        param : :class:`pybamm.parameters.Parameters` instance
             The parameters of the simulation
-        operators : :class:`pybamm.Operators` instance
+        operators : :class:`pybamm.operators.Operators` instance
             The spatial operators.
-        mesh : :class:`pybamm.Mesh` instance
+        mesh : :class:`pybamm.mesh.Mesh` instance
             The spatial and temporal discretisation.
         """
         self.param = param

--- a/pybamm/models/components/electrolyte.py
+++ b/pybamm/models/components/electrolyte.py
@@ -36,8 +36,10 @@ class Electrolyte(object):
             The initial conditions
         """
         c0 = self.param.c0 * np.ones_like(self.mesh.xc)
+        en0 = self.param.U_Pb(self.param.c0) * np.ones_like(self.mesh.xcn)
+        ep0 = self.param.U_PbO2(self.param.c0) * np.ones_like(self.mesh.xcp)
 
-        return {"c": c0}
+        return {"c": c0, "en": en0, "ep": ep0}
 
     def cation_conservation(self, c, j, flux_bcs):
         """Conservation of cations.
@@ -82,65 +84,86 @@ class Electrolyte(object):
         flux_bc_right = np.array([0])
         return (flux_bc_left, flux_bc_right)
 
-    # def current_conservation(self, c, e, j, bcs=None):
-    #     """The 1D diffusion equation.
-    #
-    #     Parameters
-    #     ----------
-    #     param : pybamm.parameters.Parameter() instance
-    #         The parameters of the simulation
-    #     variables : 2-tuple (c, e) of array_like, shape (n,)
-    #         The concentration, and potential difference.
-    #     operators : pybamm.operators.Operators() instance
-    #         The spatial operators.
-    #     current_bcs : 2-tuple of array_like, shape (1,)
-    #         Flux at the boundaries (Neumann BC).
-    #     j : array_like, shape (n,)
-    #         Interfacial current density.
-    #
-    #     Returns
-    #     -------
-    #     dedt : array_like, shape (n,)
-    #         The time derivative of the potential.
-    #
-    #     """
-    #     # Calculate current density
-    #     i = self.macinnes(variables, operators, current_bcs)
-    #
-    #     # Calculate time derivative
-    #     dedt = 1 / param.gamma_dl * (operators.div(i) - j)
-    #
-    #     return dedt
-    #
-    # def macinnes(self, c, e, bcs=None):
-    #     """The 1D current.
-    #
-    #     Parameters
-    #     ----------
-    #     param : pybamm.parameters.Parameter() instance
-    #         The parameters of the simulation
-    #     variables : 2-tuple (c, e) of array_like, shape (n,)
-    #         The concentration, and potential difference.
-    #     operators : pybamm.operators.Operators() instance
-    #         The spatial operators.
-    #     current_bcs : 2-tuple of array_like, shape (1,)
-    #         Flux at the boundaries (Neumann BC).
-    #
-    #     Returns
-    #     -------
-    #     i : array_like, shape (n+1,)
-    #         The current density.
-    #     """
-    #     c, e = variables
-    #
-    #     kappa_over_c = 1
-    #     kappa = 1
-    #
-    #     # Calculate inner current
-    #     i_inner = kappa_over_c * operators.grad(c) + kappa * operators.grad(e
-    #
-    #     # Add boundary conditions
-    #     lbc, rbc = current_bcs
-    #     i = np.concatenate([lbc, i_inner, rbc])
-    #
-    #     return i
+    def current_conservation(self, domain, c, e, j, current_bcs):
+        """The 1D diffusion equation.
+
+        Parameters
+        ----------
+        param : pybamm.parameters.Parameter() instance
+            The parameters of the simulation
+        variables : 2-tuple (c, e) of array_like, shape (n,)
+            The concentration, and potential difference.
+        operators : pybamm.operators.Operators() instance
+            The spatial operators.
+        j : array_like, shape (n,)
+            Interfacial current density.
+        current_bcs : 2-tuple of array_like, shape (1,)
+            Flux at the boundaries (Neumann BC).
+
+        Returns
+        -------
+        dedt : array_like, shape (n,)
+            The time derivative of the potential.
+
+        """
+        # Calculate current density
+        i = self.macinnes(domain, c, e, current_bcs)
+
+        # Calculate time derivative
+        if domain == "xcn":
+            gamma_dl = self.param.gamma_dl_n
+        elif domain == "xcp":
+            gamma_dl = self.param.gamma_dl_p
+
+        dedt = 1 / gamma_dl * (self.operators[domain].div(i) - j)
+
+        return dedt
+
+    def macinnes(self, domain, c, e, current_bcs):
+        """MacInnes equation for the electrolyte current density.
+
+        Parameters
+        ----------
+        domain : string
+            The domain in which to calculate the electrolyte current density.
+        c : array_like, shape (n,)
+            The electrolyte concentration.
+        e : array_like, shape (n,)
+            The potential difference.
+        current_bcs : 2-tuple of array_like, shape (1,)
+            Flux at the boundaries (Neumann BC).
+
+        Returns
+        -------
+        i : array_like, shape (n+1,)
+            The current density.
+        """
+        operators = self.operators[domain]
+        kappa_over_c = 1
+        kappa = 1
+
+        # Calculate inner current
+        i_inner = kappa_over_c * operators.grad(c) + kappa * operators.grad(e)
+
+        # Add boundary conditions
+        lbc, rbc = current_bcs
+        i = np.concatenate([lbc, i_inner, rbc])
+
+        return i
+
+    def bcs_current(self, domain, t):
+        """Boundary conditions for the current conservation equation.
+
+        Returns
+        -------
+        2-tuple of array_like, shape(1,)
+            The boundary conditions.
+
+        """
+        if domain == "xcn":
+            current_bc_left = np.array([0])
+            current_bc_right = np.array([self.param.icell(t)])
+        elif domain == "xcp":
+            current_bc_left = np.array([self.param.icell(t)])
+            current_bc_right = np.array([0])
+        return (current_bc_left, current_bc_right)

--- a/pybamm/models/components/interface.py
+++ b/pybamm/models/components/interface.py
@@ -54,14 +54,14 @@ class Interface(object):
 
         """
         if domain == "xcn":
-            assert c.shape == self.mesh.xcn.shape
-            assert e.shape == self.mesh.xcn.shape
+            assert c.shape == e.shape
+            assert e.shape[0] == len(self.mesh.xcn)
             j = self.param.iota_ref_n * c * np.sinh(e - self.param.U_Pb(c))
         elif domain == "xcs":
             j = np.zeros_like(self.mesh.xcs)
         elif domain == "xcp":
-            assert c.shape == self.mesh.xcp.shape
-            assert e.shape == self.mesh.xcp.shape
+            assert c.shape == e.shape
+            assert e.shape[0] == len(self.mesh.xcp)
             j = (
                 self.param.iota_ref_p
                 * c ** 2
@@ -69,7 +69,7 @@ class Interface(object):
                 * np.sinh(e - self.param.U_PbO2(c))
             )
         elif domain == "xc":
-            assert c.shape == self.mesh.xc.shape
+            assert c.shape[0] == len(self.mesh.xc)
             assert e.shape[0] == len(self.mesh.xcn) + len(self.mesh.xcp)
             cn, cs, cp = np.split(
                 c, np.array([self.mesh.nn - 1, self.mesh.nn + self.mesh.ns])

--- a/pybamm/models/components/interface.py
+++ b/pybamm/models/components/interface.py
@@ -10,29 +10,42 @@ import numpy as np
 class Interface(object):
     """Equations for the electrode-electrolyte interface."""
 
-    def set_simulation(self, param):
+    def set_simulation(self, param, mesh):
         """
         Assign simulation-specific objects as attributes.
 
         Parameters
         ----------
-        param : :class:`pybamm.Parameters` instance
+        param : :class:`pybamm.parameters.Parameters` instance
             The parameters of the simulation
+        operators : :class:`pybamm.operators.Operators` instance
+            The spatial operators.
+        mesh : :class:`pybamm.mesh.Mesh` instance
+            The spatial and temporal discretisation.
         """
         self.param = param
+        self.mesh = mesh
 
-    def butler_volmer(self, c, e, domain):
+    def butler_volmer(self, domain, c=None, e=None):
         """Calculates the interfacial current densities
         using Butler-Volmer kinetics.
 
         Parameters
         ----------
-        c : array_like, shape (n,)
-            The electrolyte concentration.
-        e : array_like, shape (n,)
-            The potential difference.
         domain : string
             The domain in which to calculate the interfacial current density.
+                * "xcn" or "xcp" : the interfacial current density is be
+                    calculated in the relevant electrode as a function of c and
+                    e. c and e should have the same shape as the relevant
+                    electrode mesh.
+                * "xcs" : the interfacial current density is zero
+                * "xc" : the interfacial current density will be calculated
+                    across the whole cell, calling on "xcn", "xcs" and "xcp".
+                    c should have the same shape as self.mesh.xc.
+        c : array_like, shape (n,), optional
+            The electrolyte concentration.
+        e : array_like, shape (n,), optional
+            The potential difference.
 
         Returns
         -------
@@ -41,15 +54,69 @@ class Interface(object):
 
         """
         if domain == "xcn":
+            assert c.shape == self.mesh.xcn.shape
+            assert e.shape == self.mesh.xcn.shape
             j = self.param.iota_ref_n * c * np.sinh(e - self.param.U_Pb(c))
         elif domain == "xcs":
-            j = 0 * c
+            j = np.zeros_like(self.mesh.xcs)
         elif domain == "xcp":
+            assert c.shape == self.mesh.xcp.shape
+            assert e.shape == self.mesh.xcp.shape
             j = (
                 self.param.iota_ref_p
                 * c ** 2
                 * self.param.cw(c)
                 * np.sinh(e - self.param.U_PbO2(c))
+            )
+        elif domain == "xc":
+            assert c.shape == self.mesh.xc.shape
+            assert e.shape[0] == len(self.mesh.xcn) + len(self.mesh.xcp)
+            cn, cs, cp = np.split(
+                c, np.array([self.mesh.nn - 1, self.mesh.nn + self.mesh.ns])
+            )
+            en, ep = np.split(e, np.array([self.mesh.nn - 1]))
+            j = np.concatenate(
+                [
+                    self.butler_volmer(domain, c, e)
+                    for c, e, domain in zip(
+                        [cn, cs, cp], [en, None, ep], ["xcn", "xcs", "xcp"]
+                    )
+                ]
+            )
+
+        return j
+
+    def uniform_current_density(self, domain, t):
+        """Calculates the interfacial current densities
+        using Butler-Volmer kinetics.
+
+        Parameters
+        ----------
+        domain : string
+            The domain in which to calculate the interfacial current density.
+        t : float or array_like
+            The time at which to evaluate the current density.
+
+        Returns
+        -------
+        j : array_like
+            The interfacial current density.
+
+        """
+        mesh = self.mesh
+
+        if domain == "xcn":
+            j = self.param.icell(t) / self.param.ln * np.ones_like(mesh.xcn)
+        elif domain == "xcs":
+            j = np.zeros_like(mesh.xcs)
+        elif domain == "xcp":
+            j = -self.param.icell(t) / self.param.lp * np.ones_like(mesh.xcp)
+        elif domain == "xc":
+            j = np.concatenate(
+                [
+                    self.uniform_current_density(domain, t)
+                    for domain in ["xcn", "xcs", "xcp"]
+                ]
             )
 
         return j

--- a/pybamm/operators.py
+++ b/pybamm/operators.py
@@ -28,7 +28,7 @@ class Operators(object):
         if domain not in KNOWN_DOMAINS:
             raise NotImplementedError(
                 """Domain '{}' is not implemented.
-                                      Valid choices: one of '{}'.""".format(
+                   Valid choices: one of '{}'.""".format(
                     domain, KNOWN_DOMAINS
                 )
             )

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -52,7 +52,7 @@ class Simulation(object):
         # Assign param, operators and mesh as model attributes
         self.model.set_simulation(self.param, self.operators, self.mesh)
 
-    def run(self, solver):
+    def run(self, solver, use_force=False):
         """
         Run the simulation.
 

--- a/pybamm/solver.py
+++ b/pybamm/solver.py
@@ -106,6 +106,7 @@ class Solver(object):
 
         # Solve ODEs
         def derivs(t, y):
+            print(t)
             vars.update(t, y)
             dydt = sim.model.pdes_rhs(vars)
             return dydt

--- a/pybamm/solver.py
+++ b/pybamm/solver.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
+import numpy as np
 import scipy.integrate as it
 
 KNOWN_INTEGRATORS = ["BDF", "analytical"]
@@ -129,6 +130,7 @@ class Solver(object):
         vars.update(sol.t, sol.y)
 
         # Post-process (get potentials)
+        vars.dt = np.concatenate([np.array([0]), np.diff(vars.t)])
         # TODO: write post-processing function
 
         return vars

--- a/pybamm/variables.py
+++ b/pybamm/variables.py
@@ -62,20 +62,18 @@ class Variables(object):
             if attr in ["c"]:
                 avg = np.dot(self.__dict__[attr].T, mesh.dx)
                 self.__dict__[attr + "_avg"] = avg
+
             elif attr[-1] == "n":
                 # Negative
-                var_n = self.__dict__[attr[:-1]][: mesh.nn - 1]
-                avg_n = np.sum(var_n) * mesh.dxn / param.ln
-                self.__dict__[attr[:-1] + "n_avg"] = avg_n
+                avg = np.sum(self.__dict__[attr], axis=0) * mesh.dxn / param.ln
+                self.__dict__[attr + "_avg"] = avg
 
+            elif attr[-1] == "s":
                 # Separator
-                var_s = self.__dict__[attr[:-1]][
-                    mesh.nn - 1 : mesh.nn + mesh.ns
-                ]
-                avg_s = np.sum(var_s) * mesh.dxs / param.ls
-                self.__dict__[attr[:-1] + "s_avg"] = avg_s
+                avg = np.sum(self.__dict__[attr], axis=0) * mesh.dxs / param.ls
+                self.__dict__[attr + "_avg"] = avg
 
+            elif attr[-1] == "p":
                 # Positive
-                var_p = self.__dict__[attr[:-1]][mesh.nn + mesh.ns :]
-                avg_p = np.sum(var_p) * mesh.dxp / param.lp
-                self.__dict__[attr[:-1] + "p_avg"] = avg_p
+                avg = np.sum(self.__dict__[attr], axis=0) * mesh.dxp / param.lp
+                self.__dict__[attr + "_avg"] = avg

--- a/tests/test_electrolyte.py
+++ b/tests/test_electrolyte.py
@@ -15,7 +15,9 @@ class TestElectrolyte(unittest.TestCase):
 
         # Finite volume only has h**2 convergence if the mesh is uniform?
         uniform_lengths = {"Ln": 1e-3, "Ls": 1e-3, "Lp": 1e-3}
-        param = pybamm.Parameters(optional_parameters=uniform_lengths)
+        param = pybamm.Parameters(
+            optional_parameters=uniform_lengths, tests="convergence"
+        )
 
         # Test convergence
         ns = [100, 200, 400]
@@ -24,16 +26,16 @@ class TestElectrolyte(unittest.TestCase):
             # Set up
             mesh = pybamm.Mesh(param, n)
             param.set_mesh_dependent_parameters(mesh)
-            c0 = np.cos(2 * np.pi * mesh.xc)
+            c = np.cos(2 * np.pi * mesh.xc)
             operators = {"xc": pybamm.Operators("Finite Volumes", "xc", mesh)}
             lbc = np.array([0])
             rbc = np.array([0])
-            dcdt_exact = -4 * np.pi ** 2 * c0
+            dcdt_exact = -4 * np.pi ** 2 * c
 
             # Calculate solution and errors
             electrolyte.set_simulation(param, operators, mesh)
 
-            dcdt = electrolyte.cation_conservation(c0, 0, (lbc, rbc))
+            dcdt = electrolyte.cation_conservation(c, 0, (lbc, rbc))
             errs[i] = norm(dcdt - dcdt_exact) / norm(dcdt_exact)
 
         # Expect h**2 convergence
@@ -41,6 +43,104 @@ class TestElectrolyte(unittest.TestCase):
             self.assertLess(errs[i + 1] / errs[i], 0.26)
             for i in range(len(errs) - 1)
         ]
+
+    def test_macinnes_finite_volumes_convergence(self):
+        electrolyte = pybamm.Electrolyte()
+
+        # Finite volume only has h**2 convergence if the mesh is uniform?
+        uniform_lengths = {"Ln": 1e-3, "Ls": 1e-3, "Lp": 1e-3}
+        param = pybamm.Parameters(
+            optional_parameters=uniform_lengths, tests="convergence"
+        )
+
+        # Test convergence
+        ns = [100, 200, 400]
+        errn = [0] * len(ns)
+        errp = [0] * len(ns)
+        for i, n in enumerate(ns):
+            # Set up
+            mesh = pybamm.Mesh(param, n)
+            param.set_mesh_dependent_parameters(mesh)
+            cn = np.cos(2 * np.pi * mesh.xcn)
+            cp = np.sin(2 * np.pi * mesh.xcp)
+            en = mesh.xcn ** 2
+            ep = mesh.xcp ** 2
+            operators = {
+                "xcn": pybamm.Operators("Finite Volumes", "xcn", mesh),
+                "xcp": pybamm.Operators("Finite Volumes", "xcp", mesh),
+            }
+            in_exact = -2 * np.pi * np.sin(2 * np.pi * mesh.xn) + 2 * mesh.xn
+            ip_exact = 2 * np.pi * np.cos(2 * np.pi * mesh.xp) + 2 * mesh.xp
+            current_bcs_n = (in_exact[0, None], in_exact[-1, None])
+            current_bcs_p = (ip_exact[0, None], ip_exact[-1, None])
+
+            # Calculate solution and errors
+            electrolyte.set_simulation(param, operators, mesh)
+
+            i_n = electrolyte.macinnes("xcn", cn, en, current_bcs_n)
+            i_p = electrolyte.macinnes("xcp", cp, ep, current_bcs_p)
+            errn[i] = norm(i_n - in_exact) / norm(in_exact)
+            errp[i] = norm(i_p - ip_exact) / norm(ip_exact)
+
+        # Expect h**2 convergence
+        for i in range(len(errn) - 1):
+            self.assertLess(errn[i + 1] / errn[i], 0.26)
+            self.assertLess(errp[i + 1] / errp[i], 0.26)
+
+    def test_current_conservation_finite_volumes_convergence(self):
+        electrolyte = pybamm.Electrolyte()
+
+        # Finite volume only has h**2 convergence if the mesh is uniform?
+        uniform_lengths = {"Ln": 1e-3, "Ls": 1e-3, "Lp": 1e-3}
+        param = pybamm.Parameters(
+            optional_parameters=uniform_lengths, tests="convergence"
+        )
+
+        # Test convergence
+        ns = [100, 200, 400]
+        errn = [0] * len(ns)
+        errp = [0] * len(ns)
+        for i, n in enumerate(ns):
+            # Set up
+            mesh = pybamm.Mesh(param, n)
+            param.set_mesh_dependent_parameters(mesh)
+            cn = np.cos(2 * np.pi * mesh.xcn)
+            cp = np.cos(2 * np.pi * mesh.xcp)
+            en = mesh.xcn ** 2
+            ep = mesh.xcp ** 2
+            operators = {
+                "xcn": pybamm.Operators("Finite Volumes", "xcn", mesh),
+                "xcp": pybamm.Operators("Finite Volumes", "xcp", mesh),
+            }
+            in_exact = (-2 * np.pi * np.sin(2 * np.pi * mesh.xn)) + 2 * mesh.xn
+            ip_exact = (
+                -2 * np.pi * np.sin(2 * np.pi * mesh.xp / param.lp)
+            ) + 2 * mesh.xp
+            current_bcs_n = (in_exact[0, None], in_exact[-1, None])
+            current_bcs_p = (ip_exact[0, None], ip_exact[-1, None])
+
+            # Exact solutions
+            dendt_exact = 1 / param.gamma_dl_n * (-4 * np.pi ** 2 * cn + 2)
+            depdt_exact = 1 / param.gamma_dl_p * (-4 * np.pi ** 2 * cp + 2)
+
+            # Calculate solution and errors
+            electrolyte.set_simulation(param, operators, mesh)
+            dendt = electrolyte.current_conservation(
+                "xcn", cn, en, 0, current_bcs_n
+            )
+            depdt = electrolyte.current_conservation(
+                "xcp", cp, ep, 0, current_bcs_p
+            )
+            errn[i] = norm((dendt - dendt_exact)[1:-1]) / norm(
+                dendt_exact[1:-1]
+            )
+            errp[i] = norm((depdt - depdt_exact)[1:-1]) / norm(
+                depdt_exact[1:-1]
+            )
+        # Expect h**2 convergence
+        for i in range(len(errn) - 1):
+            self.assertLess(errn[i + 1] / errn[i], 0.26)
+            self.assertLess(errp[i + 1] / errp[i], 0.26)
 
 
 if __name__ == "__main__":

--- a/tests/test_electrolyte.py
+++ b/tests/test_electrolyte.py
@@ -9,8 +9,8 @@ from numpy.linalg import norm
 import unittest
 
 
-class TestComponents(unittest.TestCase):
-    def test_electrolyte_diffusion_finite_volumes_convergence(self):
+class TestElectrolyte(unittest.TestCase):
+    def test_cation_conservation_finite_volumes_convergence(self):
         electrolyte = pybamm.Electrolyte()
 
         # Finite volume only has h**2 convergence if the mesh is uniform?
@@ -41,23 +41,6 @@ class TestComponents(unittest.TestCase):
             self.assertLess(errs[i + 1] / errs[i], 0.26)
             for i in range(len(errs) - 1)
         ]
-
-    # def test_butler_volmer(self):
-    #     param = pybamm.Parameters()
-    #     I = np.array([1])
-    #     cn = np.array([0.4])
-    #     cs = np.array([0.5])
-    #     cp = np.array([0.56])
-    #     en = np.arcsinh(I / (param.iota_ref_n * cn)) + param.U_Pb(cn)
-    #     ep = np.arcsinh(
-    #         -I / (param.iota_ref_p * cp ** 2 * param.cw(cp))
-    #     ) + param.U_PbO2(cp)
-    #     jn = models.components.butler_volmer(cn, en)
-    #     js = models.components.butler_volmer(cs, es)
-    #     jp = models.components.butler_volmer(cp, ep)
-    #     self.assertTrue(np.allclose(jn, I))
-    #     self.assertTrue(np.all(js==0))
-    #     self.assertTrue(np.allclose(jp, -I))
 
 
 if __name__ == "__main__":

--- a/tests/test_electrolyte_current.py
+++ b/tests/test_electrolyte_current.py
@@ -1,0 +1,75 @@
+#
+# Test for the reaction-diffusion model
+#
+import pybamm
+from tests.shared import pdes_io
+
+import unittest
+import numpy as np
+
+
+class TestReactionDiffusion(unittest.TestCase):
+    def setUp(self):
+        self.model = pybamm.ElectrolyteCurrentModel()
+        self.param = pybamm.Parameters()
+        target_npts = 100
+        tsteps = 100
+        tend = 1
+        self.mesh = pybamm.Mesh(
+            self.param, target_npts, tsteps=tsteps, tend=tend
+        )
+        self.param.set_mesh_dependent_parameters(self.mesh)
+
+    def tearDown(self):
+        del self.model
+        del self.param
+        del self.mesh
+
+    def test_model_shape(self):
+        for spatial_discretisation in pybamm.KNOWN_SPATIAL_DISCRETISATIONS:
+            operators = {
+                domain: pybamm.Operators(
+                    spatial_discretisation, domain, self.mesh
+                )
+                for domain in self.model.domains()
+            }
+            self.model.set_simulation(self.param, operators, self.mesh)
+            y, dydt = pdes_io(self.model)
+            self.assertEqual(y.shape, dydt.shape)
+
+    def test_model_physics(self):
+        sim = pybamm.Simulation(self.model, self.param, self.mesh)
+        solver = pybamm.Solver(
+            integrator="BDF", spatial_discretisation="Finite Volumes"
+        )
+
+        sim.run(solver)
+
+        interface = pybamm.Interface()
+        interface.set_simulation(self.param, self.mesh)
+        cn = np.ones((len(self.mesh.xcn), len(sim.vars.t)))
+        cp = np.ones((len(self.mesh.xcp), len(sim.vars.t)))
+        sim.vars.jn = interface.butler_volmer("xcn", cn, sim.vars.en)
+        sim.vars.jp = interface.butler_volmer("xcp", cp, sim.vars.ep)
+
+        sim.average()
+
+        # integral of en is known
+        jn_avg_expected = self.param.icell(sim.vars.t) / self.param.ln
+        jp_avg_expected = -self.param.icell(sim.vars.t) / self.param.lp
+
+        self.assertTrue(
+            np.allclose(sim.vars.jn_avg[1:], jn_avg_expected[1:], atol=1e-15)
+        )
+        self.assertTrue(
+            np.allclose(sim.vars.jp_avg[1:], jp_avg_expected[1:], atol=1e-15)
+        )
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    unittest.main()

--- a/tests/test_electrolyte_current.py
+++ b/tests/test_electrolyte_current.py
@@ -12,8 +12,8 @@ class TestElectrolyteCurrent(unittest.TestCase):
     def setUp(self):
         self.model = pybamm.ElectrolyteCurrentModel()
         self.param = pybamm.Parameters()
-        target_npts = 100
-        tsteps = 100
+        target_npts = 3
+        tsteps = 10
         tend = 1
         self.mesh = pybamm.Mesh(
             self.param, target_npts, tsteps=tsteps, tend=tend

--- a/tests/test_electrolyte_current.py
+++ b/tests/test_electrolyte_current.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 
-class TestReactionDiffusion(unittest.TestCase):
+class TestElectrolyteCurrent(unittest.TestCase):
     def setUp(self):
         self.model = pybamm.ElectrolyteCurrentModel()
         self.param = pybamm.Parameters()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,57 @@
+#
+# Tests for the electrolyte-electrode interface class
+#
+import pybamm
+
+import numpy as np
+
+import unittest
+
+
+class TestInterface(unittest.TestCase):
+    def setUp(self):
+        self.param = pybamm.Parameters()
+        self.mesh = pybamm.Mesh(self.param, 50)
+        self.interface = pybamm.Interface()
+        self.interface.set_simulation(self.param, self.mesh)
+
+    def test_butler_volmer(self):
+        I = self.param.icell(1)
+        cn = 0.4 * np.ones_like(self.mesh.xcn)
+        cs = 0.5 * np.ones_like(self.mesh.xcs)
+        cp = 0.56 * np.ones_like(self.mesh.xcp)
+        c = np.concatenate([cn, cs, cp])
+        en = np.arcsinh(I / (self.param.iota_ref_n * cn)) + self.param.U_Pb(cn)
+        ep = np.arcsinh(
+            -I / (self.param.iota_ref_p * cp ** 2 * self.param.cw(cp))
+        ) + self.param.U_PbO2(cp)
+        e = np.concatenate([en, ep])
+        jn = self.interface.butler_volmer("xcn", cn, en)
+        js = self.interface.butler_volmer("xcs")
+        jp = self.interface.butler_volmer("xcp", cp, ep)
+        self.assertTrue(np.allclose(jn, I))
+        self.assertTrue(np.all(js == 0))
+        self.assertTrue(np.allclose(jp, -I))
+        j = self.interface.butler_volmer("xc", c, e)
+        self.assertTrue(np.allclose(j, np.concatenate([jn, js, jp])))
+
+    def test_uniform_current_density(self):
+        t = 1
+        I = self.param.icell(t)
+        jn = self.interface.uniform_current_density("xcn", t)
+        js = self.interface.uniform_current_density("xcs", t)
+        jp = self.interface.uniform_current_density("xcp", t)
+        self.assertTrue(np.allclose(jn, I / self.param.ln))
+        self.assertTrue(np.all(js == 0))
+        self.assertTrue(np.allclose(jp, -I / self.param.lp))
+        j = self.interface.uniform_current_density("xc", t)
+        self.assertTrue(np.allclose(j, np.concatenate([jn, js, jp])))
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    unittest.main()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -26,6 +26,10 @@ class TestParameters(unittest.TestCase):
         param = pybamm.Parameters(optional_parameters="optional_test.csv")
         self.assertAlmostEqual(param.ln + param.ls + param.lp, 1, places=10)
 
+    def test_parameters_tests(self):
+        with self.assertRaises(NotImplementedError):
+            pybamm.Parameters(tests="not a test")
+
     def test_mesh_dependent_parameters(self):
         param = pybamm.Parameters()
         mesh = pybamm.Mesh(param, 10)

--- a/tests/test_reaction_diffusion.py
+++ b/tests/test_reaction_diffusion.py
@@ -40,31 +40,27 @@ class TestReactionDiffusion(unittest.TestCase):
             self.assertEqual(y.shape, dydt.shape)
 
     def test_model_physics(self):
-        simulation = pybamm.Simulation(
-            self.model, self.param, self.mesh, name="Reaction diffusion"
-        )
+        """Check that the average concentration is as expected"""
+        sim = pybamm.Simulation(self.model, self.param, self.mesh)
         solver = pybamm.Solver(
             integrator="BDF", spatial_discretisation="Finite Volumes"
         )
 
-        simulation.run(solver)
+        sim.run(solver)
 
-        simulation.average()
-        # integral of c is known
-        c_avg_expected = 1 + (self.param.sn - self.param.sp) * it.cumtrapz(
-            self.param.icell(simulation.vars.t), simulation.vars.t, initial=0.0
-        )
+        sim.average()
+
+        c_avg_expected = self.param.c0 + (
+            self.param.sn - self.param.sp
+        ) * it.cumtrapz(self.param.icell(sim.vars.t), sim.vars.t, initial=0.0)
 
         self.assertTrue(
-            np.allclose(simulation.vars.c_avg, c_avg_expected, atol=4e-16)
+            np.allclose(sim.vars.c_avg, c_avg_expected, atol=4e-16)
         )
-        # integral of j is known
-        # check convergence to steady state when current is zero
-        # concentration and porosity limits
 
     def test_model_convergence(self):
         """
-        Exact solution: c = exp(-4*pi**2*t * cos(2*pi*x))
+        Exact solution: c = exp(-4*pi**2*t) * cos(2*pi*x)
         Initial conditions: c0 = cos(2*pi*x)
         Boundary conditions: Zero flux
         Source terms: 0
@@ -72,6 +68,8 @@ class TestReactionDiffusion(unittest.TestCase):
         Can achieve "convergence" in time by changing the integrator tolerance
         Can't get h**2 convergence in space
         """
+        param = pybamm.Parameters(tests="convergence")
+        param.set_mesh_dependent_parameters(self.mesh)
 
         def c_exact(t):
             return np.exp(-4 * np.pi ** 2 * t) * np.cos(
@@ -89,7 +87,7 @@ class TestReactionDiffusion(unittest.TestCase):
         tests = {"inits": inits, "bcs": bcs, "sources": sources}
 
         model = pybamm.ReactionDiffusionModel(tests=tests)
-        simulation = pybamm.Simulation(model, self.param, self.mesh)
+        simulation = pybamm.Simulation(model, param, self.mesh)
 
         ns = [1, 2, 3]
         errs = [0] * len(ns)

--- a/tests/test_reaction_diffusion.py
+++ b/tests/test_reaction_diffusion.py
@@ -14,8 +14,8 @@ class TestReactionDiffusion(unittest.TestCase):
     def setUp(self):
         self.model = pybamm.ReactionDiffusionModel()
         self.param = pybamm.Parameters()
-        target_npts = 100
-        tsteps = 100
+        target_npts = 10
+        tsteps = 10
         tend = 1
         self.mesh = pybamm.Mesh(
             self.param, target_npts, tsteps=tsteps, tend=tend

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -4,7 +4,6 @@
 import pybamm
 
 import numpy as np
-from numpy.linalg import norm
 
 import unittest
 


### PR DESCRIPTION
# Description

Reformat models to have a different class for each model and use components from sub-methods "Electrolyte", "Interface", etc. Will be improved further by Scott.
Add an "electrolyte current" model with MacInnes + Butler-Volmer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
