### PR TITLE
#32 allow string input to domain

### DIFF
--- a/pybamm/expression_tree/domain.py
+++ b/pybamm/expression_tree/domain.py
@@ -13,17 +13,19 @@ class Domain(object):
 
     name: str
         the name of the node
-    domain : iterable of str
+    domain : iterable of str, or str
         the list of domains
 
     """
 
     def __init__(self, name, domain=[]):
         super().__init__(name)
+        if isinstance(domain, str):
+            domain = [domain]
         try:
             iter(domain)
         except TypeError:
-            raise TypeError('Domain: argument domain is not iterable')
+            raise TypeError("Domain: argument domain is not iterable")
         else:
             self.domain = domain
 

--- a/tests/test_expression_tree/test_independent_variable.py
+++ b/tests/test_expression_tree/test_independent_variable.py
@@ -13,9 +13,12 @@ class TestIndependentVariable(unittest.TestCase):
         a = pybamm.IndependentVariable("a")
         self.assertEqual(a.name, "a")
         self.assertEqual(a.domain, [])
-        a = pybamm.IndependentVariable("a", domain=['test'])
-        self.assertEqual(a.domain[0], 'test')
-        self.assertRaises(TypeError, pybamm.IndependentVariable("a", domain='test'))
+        a = pybamm.IndependentVariable("a", domain=["test"])
+        self.assertEqual(a.domain[0], "test")
+        a = pybamm.IndependentVariable("a", domain="test")
+        self.assertEqual(a.domain[0], "test")
+        with self.assertRaises(TypeError):
+            pybamm.IndependentVariable("a", domain=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Allow string input to domain (changes domain to list with single entry being the string)

Fixes #32

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
