### PR TITLE
Issue 65 process parameters bcs

### DIFF
--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -94,8 +94,12 @@ class ParameterValues(dict):
         for variable, equation in model.initial_conditions.items():
             model.initial_conditions[variable] = self.process_symbol(equation)
 
-        for variable, equation in model.boundary_conditions.items():
-            model.boundary_conditions[variable] = self.process_symbol(equation)
+        # Boundary conditions are dictionaries {"left": left bc, "right": right bc}
+        for variable, bcs in model.boundary_conditions.items():
+            for side in ["left", "right"]:
+                model.boundary_conditions[variable][side] = self.process_symbol(
+                    bcs[side]
+                )
 
     def process_symbol(self, symbol):
         """Walk through the symbol and replace any Parameter with a Value.


### PR DESCRIPTION
# Description

For processing of model parameters:
- change `ParameterValues.process_model` to take boundary conditions of the form `{"left": left bc, "right": right bc}`)
- add tests for `ParameterValues.process_model`

Fixes #65 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
