### PR TITLE
Issue 91 average diffusivity

### DIFF
--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -207,14 +207,15 @@ class BaseDiscretisation(object):
             return symbol.__class__(symbol.entries, domain=symbol.domain)
 
         else:
+            raise NotImplementedError
             # hack to copy the symbol but without a parent
             # (building tree from bottom up)
             # simply setting new_symbol.parent = None, after copying, raises a TreeError
-            parent = symbol.parent
-            symbol.parent = None
-            new_symbol = copy.copy(symbol)
-            symbol.parent = parent
-            return new_symbol
+            # parent = symbol.parent
+            # symbol.parent = None
+            # new_symbol = copy.copy(symbol)
+            # symbol.parent = parent
+            # return new_symbol
 
     def process_binary_operators(self, bin_op, y_slices, boundary_conditions):
         """Discretise binary operators in model equations.

--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -7,7 +7,6 @@ import pybamm
 
 import numpy as np
 import numbers
-import copy
 
 
 class BaseDiscretisation(object):

--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -30,6 +30,10 @@ class Array(pybamm.Symbol):
         self._entries = entries
 
     @property
+    def entries(self):
+        return self._entries
+
+    @property
     def ndim(self):
         """ returns the number of dimensions of the tensor"""
         return self._entries.ndim

--- a/pybamm/expression_tree/matrix.py
+++ b/pybamm/expression_tree/matrix.py
@@ -21,5 +21,5 @@ class Matrix(pybamm.Array):
 
     """
 
-    def __init__(self, entries, name=None):
-        super().__init__(entries, name=name)
+    def __init__(self, entries, name=None, domain=[]):
+        super().__init__(entries, name=name, domain=domain)

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -308,12 +308,16 @@ class Symbol(anytree.NodeMixin):
         """Returns True if equation has spatial derivatives (grad or div)."""
         return self.has_gradient() or self.has_divergence()
 
+    def has_gradient_and_not_divergence(self):
+        """Returns True if equation has a Gradient term and not Divergence term."""
+        return self.has_gradient() and not self.has_divergence()
+
     def has_gradient(self):
-        """Returns True if equation has a Gradient."""
+        """Returns True if equation has a Gradient term."""
         return any([isinstance(symbol, pybamm.Gradient) for symbol in self.pre_order()])
 
     def has_divergence(self):
-        """Returns True if equation has a Divergence."""
+        """Returns True if equation has a Divergence term."""
         return any(
             [isinstance(symbol, pybamm.Divergence) for symbol in self.pre_order()]
         )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,4 +5,4 @@
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 
-from test_models.standard_model_tests import StandardModelTest
+from .test_models.standard_model_tests import StandardModelTest

--- a/tests/test_discretisations/test_base_discretisations.py
+++ b/tests/test_discretisations/test_base_discretisations.py
@@ -77,6 +77,16 @@ class TestDiscretise(unittest.TestCase):
         scal_disc = disc.process_symbol(scal)
         self.assertIsInstance(scal_disc, pybamm.Scalar)
         self.assertEqual(scal_disc.value, scal.value)
+        # vector
+        vec = pybamm.Vector(np.array([1, 2, 3, 4]))
+        vec_disc = disc.process_symbol(vec)
+        self.assertIsInstance(vec_disc, pybamm.Vector)
+        np.testing.assert_array_equal(vec_disc.entries, vec.entries)
+        # matrix
+        mat = pybamm.Matrix(np.array([[1, 2, 3, 4], [5, 6, 7, 8]]))
+        mat_disc = disc.process_symbol(mat)
+        self.assertIsInstance(mat_disc, pybamm.Matrix)
+        np.testing.assert_array_equal(mat_disc.entries, mat.entries)
 
         # binary operator
         bin = var + scal
@@ -101,6 +111,10 @@ class TestDiscretise(unittest.TestCase):
         un2_disc = disc.process_symbol(un2)
         self.assertIsInstance(un2_disc, pybamm.AbsoluteValue)
         self.assertIsInstance(un2_disc.children[0], pybamm.Scalar)
+
+        # parameter should fail
+        with self.assertRaises(NotImplementedError):
+            disc.process_symbol(pybamm.Parameter("par"))
 
     def test_process_complex_expression(self):
         var1 = pybamm.Variable("var1")

--- a/tests/test_discretisations/test_base_discretisations.py
+++ b/tests/test_discretisations/test_base_discretisations.py
@@ -78,18 +78,18 @@ class TestDiscretise(unittest.TestCase):
         self.assertIsInstance(scal_disc, pybamm.Scalar)
         self.assertEqual(scal_disc.value, scal.value)
 
-        # parameter
-        par = pybamm.Parameter("par")
-        par_disc = disc.process_symbol(par)
-        self.assertIsInstance(par_disc, pybamm.Parameter)
-        self.assertEqual(par_disc.name, par.name)
-
         # binary operator
         bin = var + scal
         bin_disc = disc.process_symbol(bin, y_slices)
         self.assertIsInstance(bin_disc, pybamm.Addition)
         self.assertIsInstance(bin_disc.children[0], pybamm.StateVector)
         self.assertIsInstance(bin_disc.children[1], pybamm.Scalar)
+
+        bin2 = scal + var
+        bin2_disc = disc.process_symbol(bin2, y_slices)
+        self.assertIsInstance(bin2_disc, pybamm.Addition)
+        self.assertIsInstance(bin2_disc.children[0], pybamm.Scalar)
+        self.assertIsInstance(bin2_disc.children[1], pybamm.StateVector)
 
         # non-spatial unary operator
         un1 = -var
@@ -105,11 +105,11 @@ class TestDiscretise(unittest.TestCase):
     def test_process_complex_expression(self):
         var1 = pybamm.Variable("var1")
         var2 = pybamm.Variable("var2")
-        par1 = pybamm.Parameter("par1")
-        par2 = pybamm.Parameter("par2")
         scal1 = pybamm.Scalar("scal1")
         scal2 = pybamm.Scalar("scal2")
-        expression = (scal1 * (par1 + var2)) / ((var1 - par2) + scal2)
+        scal3 = pybamm.Scalar("scal3")
+        scal4 = pybamm.Scalar("scal4")
+        expression = (scal1 * (scal3 + var2)) / ((var1 - scal4) + scal2)
 
         disc = pybamm.BaseDiscretisation(None)
         y_slices = {var1.id: slice(53), var2.id: slice(53, 59)}
@@ -120,7 +120,7 @@ class TestDiscretise(unittest.TestCase):
         self.assertIsInstance(exp_disc.children[0].children[0], pybamm.Scalar)
         self.assertIsInstance(exp_disc.children[0].children[1], pybamm.Addition)
         self.assertTrue(
-            isinstance(exp_disc.children[0].children[1].children[0], pybamm.Parameter)
+            isinstance(exp_disc.children[0].children[1].children[0], pybamm.Scalar)
         )
         self.assertTrue(
             isinstance(exp_disc.children[0].children[1].children[1], pybamm.StateVector)
@@ -140,7 +140,7 @@ class TestDiscretise(unittest.TestCase):
             exp_disc.children[1].children[0].children[0].y_slice, y_slices[var1.id]
         )
         self.assertTrue(
-            isinstance(exp_disc.children[1].children[0].children[1], pybamm.Parameter)
+            isinstance(exp_disc.children[1].children[0].children[1], pybamm.Scalar)
         )
         self.assertIsInstance(exp_disc.children[1].children[1], pybamm.Scalar)
 

--- a/tests/test_discretisations/test_finite_volume_discretisations.py
+++ b/tests/test_discretisations/test_finite_volume_discretisations.py
@@ -57,6 +57,33 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
             # Check that the equation can be evaluated
             eqn_disc.evaluate(None, y_test)
 
+        # more testing, with boundary conditions
+        for flux, eqn in zip(
+            [
+                pybamm.grad(var),
+                pybamm.grad(var),
+                pybamm.grad(var),
+                2 * pybamm.grad(var),
+                2 * pybamm.grad(var),
+                var * pybamm.grad(var) + 2 * pybamm.grad(var),
+            ],
+            [
+                pybamm.div(pybamm.grad(var)),
+                pybamm.div(pybamm.grad(var)) + 2,
+                pybamm.div(pybamm.grad(var)) + var,
+                pybamm.div(2 * pybamm.grad(var)),
+                pybamm.div(2 * pybamm.grad(var)) + 3 * var,
+                -2 * pybamm.div(var * pybamm.grad(var) + 2 * pybamm.grad(var)),
+            ],
+        ):
+            eqn_disc = disc.process_symbol(
+                eqn,
+                y_slices,
+                {flux.id: {"left": pybamm.Scalar(0), "right": pybamm.Scalar(1)}},
+            )
+            # Check that the equation can be evaluated
+            eqn_disc.evaluate(None, y_test)
+
     def test_add_ghost_nodes(self):
         # Set up
         param = pybamm.ParameterValues(


### PR DESCRIPTION
# Description

Fixes #91 
Have re-opened #91 to fix the case where there is both a `divergence` and a `gradient`:
```
Vector * Gradient(Variable) # should do node_to_edge
Vector * Divergence(Gradient(Variable)) # should not do node_to_edge
```
In doing so, realised there was an issue in `BaseDiscretisation.process_symbol` where, in the final `else`, detaching then reattaching `symbol.parent` switches around the order of `parent.children`:
```
# before disc:
symbol = Scalar * Vector 
symbol.children -> (Scalar, Vector)
# after disc 
disc.process_symbol(symbol)
symbol.children -> (Vector, Scalar)
```
This is a problem for recognising `symbol.id` in the boundary conditions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
