### PR TITLE
Issue 136 copy symbol

### DIFF
--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -301,7 +301,9 @@ class BaseDiscretisation(object):
             return new_symbol
 
         else:
-            return copy.deepcopy(symbol)
+            new_symbol = copy.deepcopy(symbol)
+            new_symbol.parent = None
+            return new_symbol
 
     def process_binary_operators(self, bin_op, y_slices, boundary_conditions):
         """Discretise binary operators in model equations.  Performs appropriate

--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
+import copy
 import numpy as np
 
 
@@ -299,22 +300,8 @@ class BaseDiscretisation(object):
 
             return new_symbol
 
-        elif isinstance(symbol, pybamm.Scalar):
-            return pybamm.Scalar(symbol.value, domain=symbol.domain)
-
-        elif isinstance(symbol, pybamm.Array):
-            return symbol.__class__(symbol.entries, domain=symbol.domain)
-
         else:
-            raise NotImplementedError
-            # hack to copy the symbol but without a parent
-            # (building tree from bottom up)
-            # simply setting new_symbol.parent = None, after copying, raises a TreeError
-            # parent = symbol.parent
-            # symbol.parent = None
-            # new_symbol = copy.copy(symbol)
-            # symbol.parent = parent
-            # return new_symbol
+            return copy.copy(symbol)
 
     def process_binary_operators(self, bin_op, y_slices, boundary_conditions):
         """Discretise binary operators in model equations.  Performs appropriate

--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -301,7 +301,7 @@ class BaseDiscretisation(object):
             return new_symbol
 
         else:
-            return copy.copy(symbol)
+            return copy.deepcopy(symbol)
 
     def process_binary_operators(self, bin_op, y_slices, boundary_conditions):
         """Discretise binary operators in model equations.  Performs appropriate

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -47,6 +47,15 @@ class Concatenation(pybamm.Symbol):
 
         return domain
 
+    @property
+    def children(self):
+        children_list = []
+        for child in tuple(self._NodeMixin__children_):
+            if isinstance(child, pybamm.Variable):
+                child = pybamm.Variable(child.name, child.domain)
+            children_list.append(child)
+        return children_list
+
 
 class NumpyModelConcatenation(pybamm.Symbol):
     """A node in the expression tree representing a concatenation of equations.

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
-import copy
 import numpy as np
 import numbers
 
@@ -47,19 +46,6 @@ class Concatenation(pybamm.Symbol):
         domain = sorted(domain_dict, key=domain_dict.__getitem__)
 
         return domain
-
-    @property
-    def children(self):
-        """
-        Overload the children property, returning deepcopies of the children with parent
-        removed to avoid corrupting the expression tree internal data
-        """
-        children_without_parents = []
-        for child in super().children:
-            new_child = copy.deepcopy(child)
-            new_child.parent = None
-            children_without_parents.append(new_child)
-        return tuple(children_without_parents)
 
 
 class NumpyModelConcatenation(pybamm.Symbol):

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
+import copy
 import numpy as np
 import numbers
 
@@ -49,12 +50,11 @@ class Concatenation(pybamm.Symbol):
 
     @property
     def children(self):
-        children_list = []
-        for child in tuple(self._NodeMixin__children_):
-            if isinstance(child, pybamm.Variable):
-                child = pybamm.Variable(child.name, child.domain)
-            children_list.append(child)
-        return children_list
+        """
+        Overwrite the children property, returning copies of the children to avoid
+        corrupting the expression tree internal data
+        """
+        return [copy.copy(child) for child in self._NodeMixin__children_]
 
 
 class NumpyModelConcatenation(pybamm.Symbol):

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -51,10 +51,15 @@ class Concatenation(pybamm.Symbol):
     @property
     def children(self):
         """
-        Overwrite the children property, returning copies of the children to avoid
-        corrupting the expression tree internal data
+        Overwrite the children property, returning copies of the children with parent
+        removed to avoid corrupting the expression tree internal data
         """
-        return [copy.deepcopy(child) for child in self._NodeMixin__children_]
+        children_without_parents = []
+        for child in self._NodeMixin__children_:
+            new_child = copy.deepcopy(child)
+            new_child.parent = None
+            children_without_parents.append(new_child)
+        return tuple(children_without_parents)
 
 
 class NumpyModelConcatenation(pybamm.Symbol):

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
+import anytree
 import copy
 import numpy as np
 import numbers
@@ -51,11 +52,11 @@ class Concatenation(pybamm.Symbol):
     @property
     def children(self):
         """
-        Overwrite the children property, returning copies of the children with parent
+        Overload the children property, returning deepcopies of the children with parent
         removed to avoid corrupting the expression tree internal data
         """
         children_without_parents = []
-        for child in self._NodeMixin__children_:
+        for child in super().children:
             new_child = copy.deepcopy(child)
             new_child.parent = None
             children_without_parents.append(new_child)

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
-import anytree
 import copy
 import numpy as np
 import numbers

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -54,7 +54,7 @@ class Concatenation(pybamm.Symbol):
         Overwrite the children property, returning copies of the children to avoid
         corrupting the expression tree internal data
         """
-        return [copy.copy(child) for child in self._NodeMixin__children_]
+        return [copy.deepcopy(child) for child in self._NodeMixin__children_]
 
 
 class NumpyModelConcatenation(pybamm.Symbol):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -35,7 +35,7 @@ class Symbol(anytree.NodeMixin):
         for child in children:
             # copy child before adding
             # this also adds copy.deepcopy(child) to self.children
-            copy.deepcopy(child).parent = self
+            copy.copy(child).parent = self
         self.domain = domain
 
     @property

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -34,9 +34,8 @@ class Symbol(anytree.NodeMixin):
 
         for child in children:
             # copy child before adding
-            # this also adds copy.copy(child) to self.children
-            copy.copy(child).parent = self
-
+            # this also adds copy.deepcopy(child) to self.children
+            copy.deepcopy(child).parent = self
         self.domain = domain
 
     @property
@@ -192,17 +191,15 @@ class Symbol(anytree.NodeMixin):
             [str(subdomain) for subdomain in self.domain],
         )
 
-    def __copy__(self):
-        # Prepare copy
-        cls = self.__class__
-        result = cls.__new__(cls)
-        result_dict = self.__dict__
-        # Hack to remove parent without raising a TreeError
-        # Not sure whether this is a really bad idea as it accesses a semi-private
-        # variable
-        result_dict["_NodeMixin__parent"] = None
-        result.__dict__.update(result_dict)
-        return result
+    def __deepcopy__(self, memo):
+        deepcopy_method = self.__deepcopy__
+        self.__deepcopy__ = None
+        cp = copy.deepcopy(self, memo)
+        self.__deepcopy__ = deepcopy_method
+
+        # cp.parent = None
+
+        return cp
 
     def __add__(self, other):
         """return an :class:`Addition` object"""

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -34,7 +34,7 @@ class Symbol(anytree.NodeMixin):
 
         for child in children:
             # copy child before adding
-            # this also adds copy.deepcopy(child) to self.children
+            # this also adds copy.copy(child) to self.children
             copy.copy(child).parent = self
         self.domain = domain
 

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -191,14 +191,6 @@ class Symbol(anytree.NodeMixin):
             [str(subdomain) for subdomain in self.domain],
         )
 
-    def __deepcopy__(self, memo):
-        deepcopy_method = self.__deepcopy__
-        self.__deepcopy__ = None
-        cp = copy.deepcopy(self, memo)
-        self.__deepcopy__ = deepcopy_method
-
-        return cp
-
     def __add__(self, other):
         """return an :class:`Addition` object"""
         if isinstance(other, (Symbol, numbers.Number)):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -192,6 +192,18 @@ class Symbol(anytree.NodeMixin):
             [str(subdomain) for subdomain in self.domain],
         )
 
+    def __copy__(self):
+        # Prepare copy
+        cls = self.__class__
+        result = cls.__new__(cls)
+        result_dict = self.__dict__
+        # Hack to remove parent without raising a TreeError
+        # Not sure whether this is a really bad idea as it accesses a semi-private
+        # variable
+        result_dict["_NodeMixin__parent"] = None
+        result.__dict__.update(result_dict)
+        return result
+
     def __add__(self, other):
         """return an :class:`Addition` object"""
         if isinstance(other, (Symbol, numbers.Number)):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -100,6 +100,19 @@ class Symbol(anytree.NodeMixin):
             + tuple(self.domain)
         )
 
+    @property
+    def orphans(self):
+        """
+        Returning deepcopies of the children, with parents removed to avoid corrupting
+        the expression tree internal data
+        """
+        orp = []
+        for child in self.children:
+            new_child = copy.deepcopy(child)
+            new_child.parent = None
+            orp.append(new_child)
+        return tuple(orp)
+
     def render(self):
         """print out a visual representation of the tree (this node and its
         children)

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -197,8 +197,6 @@ class Symbol(anytree.NodeMixin):
         cp = copy.deepcopy(self, memo)
         self.__deepcopy__ = deepcopy_method
 
-        # cp.parent = None
-
         return cp
 
     def __add__(self, other):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -168,4 +168,6 @@ class ParameterValues(dict):
             return pybamm.Concatenation(*new_children)
 
         else:
-            return copy.deepcopy(symbol)
+            new_symbol = copy.deepcopy(symbol)
+            new_symbol.parent = None
+            return new_symbol

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -168,11 +168,4 @@ class ParameterValues(dict):
             return pybamm.Concatenation(*new_children)
 
         else:
-            # hack to copy the symbol but without a parent
-            # (building tree from bottom up)
-            # simply setting new_symbol.parent = None, after copying, raises a TreeError
-            parent = symbol.parent
-            symbol.parent = None
-            new_symbol = copy.copy(symbol)
-            symbol.parent = parent
-            return new_symbol
+            return copy.deepcopy(symbol)

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -168,11 +168,4 @@ class ParameterValues(dict):
             return pybamm.Concatenation(*new_children)
 
         else:
-            # hack to copy the symbol but without a parent
-            # (building tree from bottom up)
-            # simply setting new_symbol.parent = None, after copying, raises a TreeError
-            parent = symbol.parent
-            symbol.parent = None
-            new_symbol = copy.copy(symbol)
-            symbol.parent = parent
-            return new_symbol
+            return copy.copy(symbol)

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -168,4 +168,11 @@ class ParameterValues(dict):
             return pybamm.Concatenation(*new_children)
 
         else:
-            return copy.copy(symbol)
+            # hack to copy the symbol but without a parent
+            # (building tree from bottom up)
+            # simply setting new_symbol.parent = None, after copying, raises a TreeError
+            parent = symbol.parent
+            symbol.parent = None
+            new_symbol = copy.copy(symbol)
+            symbol.parent = parent
+            return new_symbol

--- a/tests/test_discretisations/test_base_discretisations.py
+++ b/tests/test_discretisations/test_base_discretisations.py
@@ -165,10 +165,6 @@ class TestDiscretise(unittest.TestCase):
         self.assertIsInstance(un2_disc, pybamm.AbsoluteValue)
         self.assertIsInstance(un2_disc.children[0], pybamm.Scalar)
 
-        # parameter should fail
-        with self.assertRaises(NotImplementedError):
-            disc.process_symbol(pybamm.Parameter("par"))
-
     def test_process_complex_expression(self):
         var1 = pybamm.Variable("var1")
         var2 = pybamm.Variable("var2")
@@ -265,11 +261,7 @@ class TestDiscretise(unittest.TestCase):
 
     def test_core_NotImplementedErrors(self):
         # create discretisation
-        defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.BaseDiscretisation(None, None, None)
 
         with self.assertRaises(NotImplementedError):
             disc.gradient(None, None, {})

--- a/tests/test_expression_tree/test_concatenations.py
+++ b/tests/test_expression_tree/test_concatenations.py
@@ -128,6 +128,24 @@ class TestConcatenations(unittest.TestCase):
             ),
         )
 
+    def test_unpack_concatenation(self):
+        a = pybamm.Variable("a")
+        b = pybamm.Variable("b")
+        c = pybamm.Variable("c")
+        conc = pybamm.Concatenation(a, b, c)
+        a_new, b_new, c_new = conc.children
+
+        # We should be able to manipulate the children without TreeErrors
+        self.assertIsInstance(2 * a_new, pybamm.Multiplication)
+        self.assertIsInstance(3 + b_new, pybamm.Addition)
+        self.assertIsInstance(4 - c_new, pybamm.Subtraction)
+
+        # ids should stay the same
+        self.assertEqual(a.id, a_new.id)
+        self.assertEqual(b.id, b_new.id)
+        self.assertEqual(c.id, c_new.id)
+        self.assertEqual(conc.id, pybamm.Concatenation(a_new, b_new, c_new).id)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/test_expression_tree/test_concatenations.py
+++ b/tests/test_expression_tree/test_concatenations.py
@@ -128,12 +128,12 @@ class TestConcatenations(unittest.TestCase):
             ),
         )
 
-    def test_unpack_concatenation(self):
+    def test_concatenation_orphans(self):
         a = pybamm.Variable("a")
         b = pybamm.Variable("b")
         c = pybamm.Variable("c")
         conc = pybamm.Concatenation(a, b, c)
-        a_new, b_new, c_new = conc.children
+        a_new, b_new, c_new = conc.orphans
 
         # We should be able to manipulate the children without TreeErrors
         self.assertIsInstance(2 * a_new, pybamm.Multiplication)

--- a/tests/test_expression_tree/test_symbol.py
+++ b/tests/test_expression_tree/test_symbol.py
@@ -231,6 +231,17 @@ class TestSymbol(unittest.TestCase):
         self.assertFalse(algebraic_eqn.has_gradient())
         self.assertFalse(algebraic_eqn.has_divergence())
 
+    def test_orphans(self):
+        a = pybamm.Symbol("a")
+        b = pybamm.Symbol("b")
+        sum = a + b
+
+        a_orp, b_orp = sum.orphans
+        self.assertIsNone(a_orp.parent)
+        self.assertIsNone(b_orp.parent)
+        self.assertEqual(a.id, a_orp.id)
+        self.assertEqual(b.id, b_orp.id)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description

- Use `deepcopy` instead of `copy` when processing parameters, discretising and unpacking a Concatenation. This should help to avoid some TreeErrors to do with corrupt internal tree data. Still use copy when creating the expression tree (in `Symbol.__init__`) for speed/memory
- Simplify `ParameterValues.process_symbol` and `BaseDiscretisation.process_symbol` accordingly

Fixes #136 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
