### PR TITLE
Changed geometry keys to indepedent variables and added tests for each

### DIFF
--- a/pybamm/discretisations/meshes.py
+++ b/pybamm/discretisations/meshes.py
@@ -7,7 +7,14 @@ from __future__ import print_function, unicode_literals
 import numpy as np
 import pybamm
 
-KNOWN_DOMAINS = ["negative electrode", "separator", "positive electrode", "test"]
+KNOWN_DOMAINS = [
+    "negative electrode",
+    "separator",
+    "positive electrode",
+    "test",
+    "negative particle",
+    "positive particle",
+]
 
 
 class Mesh(dict):

--- a/pybamm/geometry/geometry.py
+++ b/pybamm/geometry/geometry.py
@@ -76,7 +76,8 @@ class Geometry3DMacro(Geometry1DMacro):
 
         z_lim = {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
 
-        for domain in self["macro"]:
-            self["macro"][domain][y] = y_lim
-            self["macro"][domain][z] = z_lim
+        MACRO_DOMAINS = ["negative electrode", "separator", "positive electrode"]
+        for domain in MACRO_DOMAINS:
+            self[domain][y] = y_lim
+            self[domain][z] = z_lim
         self.update(custom_geometry)

--- a/pybamm/geometry/geometry.py
+++ b/pybamm/geometry/geometry.py
@@ -25,12 +25,14 @@ class Geometry(dict):
 class Geometry1DMacro(Geometry):
     def __init__(self, custom_geometry={}):
         super().__init__()
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        x = pybamm.IndependentVariable("x", whole_cell)
         ln = pybamm.standard_parameters.ln
         ls = pybamm.standard_parameters.ls
 
-        self["negative electrode"] = {"x": {"min": pybamm.Scalar(0), "max": ln}}
-        self["separator"] = {"x": {"min": ln, "max": ln + ls}}
-        self["positive electrode"] = {"x": {"min": ln + ls, "max": pybamm.Scalar(1)}}
+        self["negative electrode"] = {x: {"min": pybamm.Scalar(0), "max": ln}}
+        self["separator"] = {x: {"min": ln, "max": ln + ls}}
+        self["positive electrode"] = {x: {"min": ln + ls, "max": pybamm.Scalar(1)}}
 
         # update with custom geometry if non empty
         self.update(custom_geometry)
@@ -40,11 +42,13 @@ class Geometry1DMicro(Geometry):
     def __init__(self, custom_geometry={}):
         super().__init__()
 
+        r = pybamm.IndependentVariable("r", ["negative particle", "positive particle"])
+
         self["negative particle"] = {
-            "r": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
+            r: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
         }
         self["positive particle"] = {
-            "r": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
+            r: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
         }
         # update with custom geometry if non empty
         self.update(custom_geometry)
@@ -64,11 +68,15 @@ class Geometry3DMacro(Geometry1DMacro):
     def __init__(self, custom_geometry={}):
         super().__init__()
 
-        y = {"min": pybamm.Scalar(0), "max": pybamm.standard_parameters.ly}
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        y = pybamm.IndependentVariable("y", whole_cell)
+        z = pybamm.IndependentVariable("z", whole_cell)
 
-        z = {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
+        y_lim = {"min": pybamm.Scalar(0), "max": pybamm.standard_parameters.ly}
+
+        z_lim = {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
 
         for domain in self["macro"]:
-            self["macro"][domain]["y"] = y
-            self["macro"][domain]["z"] = z
+            self["macro"][domain][y] = y_lim
+            self["macro"][domain][z] = z_lim
         self.update(custom_geometry)

--- a/pybamm/parameters/standard_parameters.py
+++ b/pybamm/parameters/standard_parameters.py
@@ -82,6 +82,10 @@ Ls = Parameter("Ls")
 Lp = Parameter("Lp")
 Lx = Ln + Ls + Lp
 
+# 3D Geometry
+Ly = Parameter("Ly")
+Lz = Parameter("Lz")
+
 # Microscale Geometry
 R_n = Parameter("R_n")
 R_p = Parameter("R_p")
@@ -119,6 +123,8 @@ cp0_dimensional = Parameter("cp0")  # Initial li concentration in pos electrode
 ln = Ln / Lx
 ls = Ls / Lx
 lp = Lp / Lx
+ly = Ly / Lz
+lz = Lz / Lz
 
 # Microscale Geometry
 epsilon_n = Parameter("epsilon_n")  # Electrolyte volume fraction in neg electrode

--- a/tests/test_geometry/test_geometry.py
+++ b/tests/test_geometry/test_geometry.py
@@ -2,11 +2,61 @@
 # Tests for the base model class
 #
 import pybamm
+import unittest
 
 
-class StandardGeometryTests:
-    def test_add_custom_geometry(self, geometry):
+class TestGeometry1DMacro(unittest.TestCase):
+    def test_add_custom_geometry(self):
+        geometry = pybamm.Geometry1DMacro()
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        x = pybamm.IndependentVariable("x", whole_cell)
+        custom_geometry = {
+            "negative electrode": {
+                x: {"min": pybamm.Scalar(1), "max": pybamm.Scalar(2)}
+            }
+        }
+        geometry.update(custom_geometry)
+        self.assertEqual(
+            geometry["negative electrode"], custom_geometry["negative electrode"]
+        )
 
+    def test_geometry_keys(self):
+        geometry = pybamm.Geometry1DMacro()
+        for spatial_vars in geometry.values():
+            all(
+                self.assertIsInstance(spatial_var, pybamm.IndependentVariable)
+                for spatial_var in spatial_vars.keys()
+            )
+
+
+class TestGeometry1DMicro(unittest.TestCase):
+    def test_add_custom_geometry(self):
+        geometry = pybamm.Geometry1DMicro()
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        x = pybamm.IndependentVariable("x", whole_cell)
+        custom_geometry = {
+            "negative electrode": {
+                x: {"min": pybamm.Scalar(1), "max": pybamm.Scalar(2)}
+            }
+        }
+        geometry.update(custom_geometry)
+
+        self.assertEqual(
+            geometry["negative electrode"], custom_geometry["negative electrode"]
+        )
+
+    def test_geometry_keys(self):
+        geometry = pybamm.Geometry1DMicro()
+        for spatial_vars in geometry.values():
+            all(
+                self.assertIsInstance(spatial_var, pybamm.IndependentVariable)
+                for spatial_var in spatial_vars.keys()
+            )
+
+
+class TestGeometry3DMacro(unittest.TestCase):
+    def test_add_custom_geometry(self):
+        geometry = pybamm.Geometry3DMacro()
         whole_cell = ["negative electrode", "separator", "positive electrode"]
         x = pybamm.IndependentVariable("x", whole_cell)
         custom_geometry = {
@@ -15,47 +65,15 @@ class StandardGeometryTests:
             }
         }
 
+        geometry.update(custom_geometry)
         self.assertEqual(
             geometry["negative electrode"], custom_geometry["negative electrode"]
         )
 
-    def test_geometry_keys(self, geometry):
-        # checks that keys are pybamm.IndependentVariables
-        keys = list(geometry.keys())
-        all(self.assertIsInstance(key, pybamm.IndependentVariable) for key in keys)
-
-
-class TestGeometry1DMacro:
-    def test_add_custom_geometry(self):
-        geometry = pybamm.Geometry1DMacro()
-        tests = StandardGeometryTests()
-        tests.test_add_custom_geometry(geometry)
-
-    def test_geometry_keys(self):
-        geometry = pybamm.Geometry1DMacro()
-        tests = StandardGeometryTests(geometry)
-        tests.test_add_custom_geometry(geometry)
-
-
-class TestGeometry1DMicro:
-    def test_add_custom_geometry(self):
-        geometry = pybamm.Geometry1DMicro()
-        tests = StandardGeometryTests()
-        tests.test_add_custom_geometry(geometry)
-
-    def test_geometry_keys(self):
-        geometry = pybamm.Geometry1DMicro()
-        tests = StandardGeometryTests(geometry)
-        tests.test_add_custom_geometry(geometry)
-
-
-class TestGeometry3DMacro:
-    def test_add_custom_geometry(self):
-        geometry = pybamm.Geometry3DMacro()
-        tests = StandardGeometryTests()
-        tests.test_add_custom_geometry(geometry)
-
     def test_geometry_keys(self):
         geometry = pybamm.Geometry3DMacro()
-        tests = StandardGeometryTests(geometry)
-        tests.test_add_custom_geometry(geometry)
+        for spatial_vars in geometry.values():
+            all(
+                self.assertIsInstance(spatial_var, pybamm.IndependentVariable)
+                for spatial_var in spatial_vars.keys()
+            )

--- a/tests/test_geometry/test_geometry.py
+++ b/tests/test_geometry/test_geometry.py
@@ -4,17 +4,58 @@
 import pybamm
 
 
-class TestGeometry:
-    def test_add_custom_geometry(self):
+class StandardGeometryTests:
+    def test_add_custom_geometry(self, geometry):
+
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        x = pybamm.IndependentVariable("x", whole_cell)
         custom_geometry = {
             "negative electrode": {
-                "x": {"min": pybamm.Scalar(1), "max": pybamm.Scalar(2)}
+                x: {"min": pybamm.Scalar(1), "max": pybamm.Scalar(2)}
             }
         }
-        geometry = pybamm.Geometry1DMacro(custom_geometry)
 
         self.assertEqual(
             geometry["negative electrode"], custom_geometry["negative electrode"]
         )
 
-    # process geometry test conducted within TestParameterValues
+    def test_geometry_keys(self, geometry):
+        # checks that keys are pybamm.IndependentVariables
+        keys = list(geometry.keys())
+        all(self.assertIsInstance(key, pybamm.IndependentVariable) for key in keys)
+
+
+class TestGeometry1DMacro:
+    def test_add_custom_geometry(self):
+        geometry = pybamm.Geometry1DMacro()
+        tests = StandardGeometryTests()
+        tests.test_add_custom_geometry(geometry)
+
+    def test_geometry_keys(self):
+        geometry = pybamm.Geometry1DMacro()
+        tests = StandardGeometryTests(geometry)
+        tests.test_add_custom_geometry(geometry)
+
+
+class TestGeometry1DMicro:
+    def test_add_custom_geometry(self):
+        geometry = pybamm.Geometry1DMicro()
+        tests = StandardGeometryTests()
+        tests.test_add_custom_geometry(geometry)
+
+    def test_geometry_keys(self):
+        geometry = pybamm.Geometry1DMicro()
+        tests = StandardGeometryTests(geometry)
+        tests.test_add_custom_geometry(geometry)
+
+
+class TestGeometry3DMacro:
+    def test_add_custom_geometry(self):
+        geometry = pybamm.Geometry3DMacro()
+        tests = StandardGeometryTests()
+        tests.test_add_custom_geometry(geometry)
+
+    def test_geometry_keys(self):
+        geometry = pybamm.Geometry3DMacro()
+        tests = StandardGeometryTests(geometry)
+        tests.test_add_custom_geometry(geometry)


### PR DESCRIPTION
The keys of the geometry dictionary are now independent variables. A set of tests have also been added to check that each key is an instance of `pybamm.IndependentVariable`

Fixes #132 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
