### PR TITLE
Issue 9 add mesh and operators for spherical domian

### DIFF
--- a/pybamm/discretisations/meshes.py
+++ b/pybamm/discretisations/meshes.py
@@ -7,7 +7,14 @@ from __future__ import print_function, unicode_literals
 import numpy as np
 import pybamm
 
-KNOWN_DOMAINS = ["negative electrode", "separator", "positive electrode", "test"]
+KNOWN_DOMAINS = [
+    "negative electrode",
+    "separator",
+    "positive electrode",
+    "test",
+    "negative particle",
+    "positive particle",
+]
 
 
 class Mesh(dict):

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -37,6 +37,20 @@ class TestDefaults1DMacro:
         }
 
 
+class TestDefaults1DParticle:
+    def __init__(self, n):
+        self.geometry = {
+            "negative particle": {
+                "r": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
+            }
+        }
+        self.param = pybamm.ParameterValues(base_parameters={})
+        self.param.process_geometry(self.geometry)
+        self.mesh_type = pybamm.Mesh
+        self.submesh_pts = {"negative particle": {"r": n}}
+        self.submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
+
+
 class DiscretisationForTesting(pybamm.BaseDiscretisation):
     """Identity operators, no boundary conditions."""
 

--- a/tests/test_discretisations/test_finite_volume_discretisations.py
+++ b/tests/test_discretisations/test_finite_volume_discretisations.py
@@ -186,6 +186,62 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
             div_eqn_disc.evaluate(None, linear_y), np.zeros_like(combined_submesh.nodes)
         )
 
+    def test_spherical_grad_div_shapes_Dirichlet_bcs(self):
+        """
+        Test grad and div with Dirichlet boundary conditions (applied by grad on var)
+        """
+        # create discretisation
+        defaults = shared.TestDefaults1DParticle(10)
+        disc = pybamm.FiniteVolumeDiscretisation(
+            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
+        )
+        disc.mesh_geometry(defaults.geometry)
+        mesh = disc.mesh
+
+        combined_submesh = mesh.combine_submeshes("negative particle")
+
+        mesh.add_ghost_meshes()
+        disc.mesh.add_ghost_meshes()
+
+        # grad
+        # grad(r) == 1
+        var = pybamm.Variable("var", domain=["negative particle"])
+        grad_eqn = pybamm.grad(var)
+        boundary_conditions = {
+            var.id: {"left": pybamm.Scalar(1), "right": pybamm.Scalar(1)}
+        }
+        y_slices = disc.get_variable_slices([var])
+        grad_eqn_disc = disc.process_symbol(grad_eqn, y_slices, boundary_conditions)
+
+        constant_y = np.ones_like(combined_submesh.nodes)
+        np.testing.assert_array_equal(
+            grad_eqn_disc.evaluate(None, constant_y),
+            np.zeros_like(combined_submesh.edges),
+        )
+
+        boundary_conditions = {
+            var.id: {"left": pybamm.Scalar(0), "right": pybamm.Scalar(1)}
+        }
+        y_linear = combined_submesh.nodes
+        grad_eqn_disc = disc.process_symbol(grad_eqn, y_slices, boundary_conditions)
+        np.testing.assert_array_almost_equal(
+            grad_eqn_disc.evaluate(None, y_linear), np.ones_like(combined_submesh.edges)
+        )
+
+        # div: test on linear r^2
+        # div (grad r^2) = 6
+        const = 6 * np.ones(combined_submesh.npts)
+        N = pybamm.grad(var)
+        div_eqn = pybamm.div(N)
+        boundary_conditions = {
+            var.id: {"left": pybamm.Scalar(6), "right": pybamm.Scalar(6)}
+        }
+
+        div_eqn_disc = disc.process_symbol(div_eqn, y_slices, boundary_conditions)
+        np.testing.assert_array_almost_equal(
+            div_eqn_disc.evaluate(None, const), np.zeros_like(combined_submesh.nodes)
+        )
+
     def test_grad_div_shapes_Neumann_bcs(self):
         """Test grad and div with Neumann boundary conditions (applied by div on N)"""
         whole_cell = ["negative electrode", "separator", "positive electrode"]
@@ -228,6 +284,52 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         )
         np.testing.assert_array_almost_equal(
             div_eqn_disc.evaluate(None, linear_y), np.zeros_like(combined_submesh.nodes)
+        )
+
+    def test_spherical_grad_div_shapes_Neumann_bcs(self):
+        """Test grad and div with Neumann boundary conditions (applied by div on N)"""
+
+        # create discretisation
+        defaults = shared.TestDefaults1DParticle(10)
+        disc = pybamm.FiniteVolumeDiscretisation(
+            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
+        )
+        disc.mesh_geometry(defaults.geometry)
+        mesh = disc.mesh
+
+        combined_submesh = mesh.combine_submeshes("negative particle")
+
+        # grad
+        var = pybamm.Variable("var", domain="negative particle")
+        grad_eqn = pybamm.grad(var)
+        y_slices = disc.get_variable_slices([var])
+        grad_eqn_disc = disc.process_symbol(grad_eqn, y_slices, {})
+
+        constant_y = np.ones_like(combined_submesh.nodes)
+        np.testing.assert_array_equal(
+            grad_eqn_disc.evaluate(None, constant_y),
+            np.zeros_like(combined_submesh.edges[1:-1]),
+        )
+
+        linear_y = combined_submesh.nodes
+        np.testing.assert_array_almost_equal(
+            grad_eqn_disc.evaluate(None, linear_y),
+            np.ones_like(combined_submesh.edges[1:-1]),
+        )
+        # div
+        # div ( grad(r^2) ) == 6 , N_left = N_right = 0
+        N = pybamm.grad(var)
+        div_eqn = pybamm.div(N)
+        boundary_conditions = {
+            N.id: {"left": pybamm.Scalar(0), "right": pybamm.Scalar(0)}
+        }
+        div_eqn_disc = disc.process_symbol(div_eqn, y_slices, boundary_conditions)
+
+        linear_y = combined_submesh.nodes
+        const = 6 * np.ones(combined_submesh.npts)
+
+        np.testing.assert_array_almost_equal(
+            div_eqn_disc.evaluate(None, const), np.zeros_like(combined_submesh.nodes)
         )
 
     def test_grad_div_shapes_mixed_domain(self):

--- a/tests/test_discretisations/test_finite_volume_discretisations.py
+++ b/tests/test_discretisations/test_finite_volume_discretisations.py
@@ -481,21 +481,12 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         }
 
         def get_l2_error(n):
-            geometry = {
-                "negative particle": {
-                    "r": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}
-                }
-            }
-            param = pybamm.ParameterValues(base_parameters={})
-            param.process_geometry(geometry)
-            mesh_type = pybamm.Mesh
-            submesh_pts = {"negative particle": {"r": n}}
-            submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
+            defaults = shared.TestDefaults1DParticle(n)
 
             disc = pybamm.FiniteVolumeDiscretisation(
-                mesh_type, submesh_pts, submesh_types
+                defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
             )
-            disc.mesh_geometry(geometry)
+            disc.mesh_geometry(defaults.geometry)
             mesh = disc.mesh["negative particle"]
             r = mesh.nodes
 


### PR DESCRIPTION
# Description

Mesh remains unchanged as previously discussed. Divergence is changed in case of negative or positive particles. No other changes to operators are required. 

A convergence test for divergence operator is provide.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
