### PR TITLE
Issue 133 refactor meshing to occur outside discretisation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,8 @@ Contents
 .. toctree::
 
     source/expression_tree/index
+    source/geometry/index
+    source/meshes/index
     source/models/index
     source/parameters/index
     source/discretisations/index

--- a/docs/source/geometry/geometry.rst
+++ b/docs/source/geometry/geometry.rst
@@ -1,0 +1,14 @@
+Geometry
+==========
+
+.. autoclass:: pybamm.Geometry
+    :members:
+
+.. autoclass:: pybamm.Geometry1DMacro
+    :members:
+
+.. autoclass:: pybamm.Geometry1DMicro
+    :members:
+    
+.. autoclass:: pybamm.Geometry3DMacro
+    :members:

--- a/docs/source/geometry/index.rst
+++ b/docs/source/geometry/index.rst
@@ -1,0 +1,7 @@
+Geometry
+========
+
+.. toctree::
+
+  geometry
+ 

--- a/docs/source/meshes/index.rst
+++ b/docs/source/meshes/index.rst
@@ -1,0 +1,7 @@
+Meshes
+======
+
+.. toctree::
+  
+  meshes
+  submeshes

--- a/docs/source/meshes/meshes.rst
+++ b/docs/source/meshes/meshes.rst
@@ -1,0 +1,5 @@
+Meshes
+==========
+
+.. autoclass:: pybamm.Mesh
+    :members:

--- a/docs/source/meshes/submeshes.rst
+++ b/docs/source/meshes/submeshes.rst
@@ -1,0 +1,8 @@
+Sub Meshes
+==========
+
+.. autoclass:: pybamm.SubMesh1D
+    :members:
+
+.. autoclass:: pybamm.Uniform1DSubMesh
+    :members:

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -125,8 +125,9 @@ from .discretisations.finite_volume_discretisations import (
     FiniteVolumeDiscretisation,
     NodeToEdge,
 )
-from .discretisations.meshes import KNOWN_DOMAINS
-from .discretisations.meshes import Mesh, SubMesh1D, Uniform1DSubMesh
+from .meshes.meshes import KNOWN_DOMAINS
+from .meshes.meshes import Mesh
+from .meshes.submeshes import SubMesh1D, Uniform1DSubMesh
 
 #
 # Simulation class

--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -22,7 +22,7 @@ class BaseDiscretisation(object):
         the types of submeshes being employed on each of the subdomains
     """
 
-    def __init__(mesh):
+    def __init__(self, mesh):
         self._mesh = mesh
 
     @property

--- a/pybamm/discretisations/base_discretisation.py
+++ b/pybamm/discretisations/base_discretisation.py
@@ -22,25 +22,14 @@ class BaseDiscretisation(object):
         the types of submeshes being employed on each of the subdomains
     """
 
-    def __init__(self, mesh_type, submesh_pts, submesh_types):
-        self.mesh_type = mesh_type
-        self.submesh_pts = submesh_pts
-        self.submesh_types = submesh_types
-
-        self._mesh = {}
+    def __init__(mesh):
+        self._mesh = mesh
 
     @property
     def mesh(self):
         return self._mesh
 
-    @mesh.setter
-    def mesh(self, mesh_in):
-        self._mesh = mesh_in
-
-    def mesh_geometry(self, geometry):
-        self._mesh = self.mesh_type(geometry, self.submesh_types, self.submesh_pts)
-
-    def process_model(self, model, geometry):
+    def process_model(self, model):
         """Discretise a model.
         Currently inplace, could be changed to return a new model.
 
@@ -51,9 +40,6 @@ class BaseDiscretisation(object):
             boundary_conditions (all dicts of {variable: equation})
 
         """
-
-        # Set the mesh
-        self._mesh = self.mesh_type(geometry, self.submesh_types, self.submesh_pts)
 
         # Set the y split for variables
         variables = list(model.rhs.keys()) + list(model.algebraic.keys())

--- a/pybamm/discretisations/finite_volume_discretisations.py
+++ b/pybamm/discretisations/finite_volume_discretisations.py
@@ -20,8 +20,8 @@ class FiniteVolumeDiscretisation(pybamm.BaseDiscretisation):
     **Extends:** :class:`pybamm.BaseDiscretisation`
     """
 
-    def __init__(self, mesh_type, submesh_pts, submesh_types):
-        super().__init__(mesh_type, submesh_pts, submesh_types)
+    def __init__(self, mesh):
+        super().__init__(mesh)
 
     def compute_diffusivity(self, symbol):
         """

--- a/pybamm/meshes/meshes.py
+++ b/pybamm/meshes/meshes.py
@@ -74,7 +74,7 @@ class Mesh(dict):
                 [self[submeshnames[0]].edges]
                 + [self[submeshname].edges[1:] for submeshname in submeshnames[1:]]
             )
-            return SubMesh1D(combined_submesh_edges)
+            return pybamm.SubMesh1D(combined_submesh_edges)
         else:
             raise pybamm.DomainError("submesh edges are not aligned")
 

--- a/pybamm/meshes/meshes.py
+++ b/pybamm/meshes/meshes.py
@@ -86,47 +86,8 @@ class Mesh(dict):
 
             # left ghost cell: two edges, one node, to the left of existing submesh
             lgs_edges = np.array([2 * edges[0] - edges[1], edges[0]])
-            self[submeshname + "_left ghost cell"] = SubMesh1D(lgs_edges)
+            self[submeshname + "_left ghost cell"] = pybamm.SubMesh1D(lgs_edges)
 
             # right ghost cell: two edges, one node, to the right of existing submesh
             rgs_edges = np.array([edges[-1], 2 * edges[-1] - edges[-2]])
-            self[submeshname + "_right ghost cell"] = SubMesh1D(rgs_edges)
-
-
-class SubMesh1D:
-    """ Submesh class.
-        Contains the position of the nodes and the number of mesh points.
-
-        Parameters
-        ----------
-        domain : dict
-            A dictionary that contains the limits of the spatial variables
-        npts : dict
-            A dictionary that contains the number of points to be used on each
-            spatial variable
-        """
-
-    def __init__(self, edges):
-        self.edges = edges
-        self.nodes = (self.edges[1:] + self.edges[:-1]) / 2
-        self.d_edges = np.diff(self.edges)
-        self.d_nodes = np.diff(self.nodes)
-        self.npts = self.nodes.size
-
-
-class Uniform1DSubMesh(SubMesh1D):
-    """
-    A class to generate a uniform submesh on a 1D domain
-    """
-
-    def __init__(self, lims, npts):
-
-        # currently accept lims and npts as dicts. This may get changed at a future
-        # date depending on the form of mesh we desire for 2D/3D
-
-        spatial_lims = list(lims.values())[0]
-        npts = list(npts.values())[0]
-
-        edges = np.linspace(spatial_lims["min"], spatial_lims["max"], npts + 1)
-
-        super().__init__(edges)
+            self[submeshname + "_right ghost cell"] = pybamm.SubMesh1D(rgs_edges)

--- a/pybamm/meshes/submeshes.py
+++ b/pybamm/meshes/submeshes.py
@@ -1,0 +1,46 @@
+#
+# Native PyBaMM Meshes
+#
+from __future__ import absolute_import, division
+from __future__ import print_function, unicode_literals
+
+import numpy as np
+
+
+class SubMesh1D:
+    """ Submesh class.
+        Contains the position of the nodes and the number of mesh points.
+
+        Parameters
+        ----------
+        domain : dict
+            A dictionary that contains the limits of the spatial variables
+        npts : dict
+            A dictionary that contains the number of points to be used on each
+            spatial variable
+        """
+
+    def __init__(self, edges):
+        self.edges = edges
+        self.nodes = (self.edges[1:] + self.edges[:-1]) / 2
+        self.d_edges = np.diff(self.edges)
+        self.d_nodes = np.diff(self.nodes)
+        self.npts = self.nodes.size
+
+
+class Uniform1DSubMesh(SubMesh1D):
+    """
+    A class to generate a uniform submesh on a 1D domain
+    """
+
+    def __init__(self, lims, npts):
+
+        # currently accept lims and npts as dicts. This may get changed at a future
+        # date depending on the form of mesh we desire for 2D/3D
+
+        spatial_lims = list(lims.values())[0]
+        npts = list(npts.values())[0]
+
+        edges = np.linspace(spatial_lims["min"], spatial_lims["max"], npts + 1)
+
+        super().__init__(edges)

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -67,11 +67,8 @@ class BaseModel(object):
             "positive electrode": pybamm.Uniform1DSubMesh,
         }
 
-        mesh_type = pybamm.Mesh
-
-        self.default_discretisation = pybamm.FiniteVolumeDiscretisation(
-            mesh_type, submesh_pts, submesh_types
-        )
+        self.mesh = pybamm.Mesh(self.default_geometry, submesh_types, submesh_pts)
+        self.default_discretisation = pybamm.FiniteVolumeDiscretisation(self.mesh)
         self.default_solver = pybamm.ScipySolver(method="RK45")
 
     def _set_dict(self, dict, name):

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 class TestDefaults1DMacro:
-    def __init__(self, n=0):
+    def __init__(self, npts=0):
         self.param = pybamm.ParameterValues(
             base_parameters={"Ln": 0.3, "Ls": 0.3, "Lp": 0.3}
         )
@@ -16,10 +16,10 @@ class TestDefaults1DMacro:
         self.param.process_geometry(self.geometry)
 
         self.submesh_pts = {
-                "negative electrode": {"x": 40},
-                "separator": {"x": 25},
-                "positive electrode": {"x": 35},
-            }
+            "negative electrode": {"x": 40},
+            "separator": {"x": 25},
+            "positive electrode": {"x": 35},
+        }
 
         self.submesh_types = {
             "negative electrode": pybamm.Uniform1DSubMesh,
@@ -27,7 +27,7 @@ class TestDefaults1DMacro:
             "positive electrode": pybamm.Uniform1DSubMesh,
         }
 
-        if n!=0:
+        if npts != 0:
             n = 3 * round(npts / 3)
             self.submesh_pts = {
                 "negative electrode": {"x": n},
@@ -36,8 +36,6 @@ class TestDefaults1DMacro:
             }
 
         self.mesh = pybamm.Mesh(self.geometry, self.submesh_types, self.submesh_pts)
-
-    def set_equal_pts(self, npts):
 
 
 class TestDefaults1DParticle:
@@ -49,16 +47,17 @@ class TestDefaults1DParticle:
         }
         self.param = pybamm.ParameterValues(base_parameters={})
         self.param.process_geometry(self.geometry)
-        self.mesh_type = pybamm.Mesh
         self.submesh_pts = {"negative particle": {"r": n}}
         self.submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
+
+        self.mesh = pybamm.Mesh(self.geometry, self.submesh_types, self.submesh_pts)
 
 
 class DiscretisationForTesting(pybamm.BaseDiscretisation):
     """Identity operators, no boundary conditions."""
 
     def __init__(self, mesh):
-        super().__init__(self, mesh)
+        super().__init__(mesh)
 
     def gradient(self, symbol, y_slices, boundary_conditions):
         discretised_symbol = self.process_symbol(symbol, y_slices, boundary_conditions)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 class TestDefaults1DMacro:
-    def __init__(self):
+    def __init__(self, n=0):
         self.param = pybamm.ParameterValues(
             base_parameters={"Ln": 0.3, "Ls": 0.3, "Lp": 0.3}
         )
@@ -16,35 +16,35 @@ class TestDefaults1DMacro:
         self.param.process_geometry(self.geometry)
 
         self.submesh_pts = {
-            "negative electrode": {"x": 40},
-            "separator": {"x": 25},
-            "positive electrode": {"x": 35},
-        }
+                "negative electrode": {"x": 40},
+                "separator": {"x": 25},
+                "positive electrode": {"x": 35},
+            }
+
         self.submesh_types = {
             "negative electrode": pybamm.Uniform1DSubMesh,
             "separator": pybamm.Uniform1DSubMesh,
             "positive electrode": pybamm.Uniform1DSubMesh,
         }
 
-        self.mesh_type = pybamm.Mesh
+        if n!=0:
+            n = 3 * round(npts / 3)
+            self.submesh_pts = {
+                "negative electrode": {"x": n},
+                "separator": {"x": n},
+                "positive electrode": {"x": n},
+            }
+
+        self.mesh = pybamm.Mesh(self.geometry, self.submesh_types, self.submesh_pts)
 
     def set_equal_pts(self, npts):
-        n = 3 * round(npts / 3)
-        self.submesh_pts = {
-            "negative electrode": {"x": n},
-            "separator": {"x": n},
-            "positive electrode": {"x": n},
-        }
 
 
 class DiscretisationForTesting(pybamm.BaseDiscretisation):
     """Identity operators, no boundary conditions."""
 
-    def __init__(self, mesh_type, submesh_pts, submesh_types):
-        super().__init__(mesh_type, submesh_pts, submesh_types)
-
-    def set_mesh(self, geometry):
-        self._mesh = self.mesh_type(geometry, self.submesh_types, self.submesh_pts)
+    def __init__(self, mesh):
+        super().__init__(self, mesh)
 
     def gradient(self, symbol, y_slices, boundary_conditions):
         discretised_symbol = self.process_symbol(symbol, y_slices, boundary_conditions)

--- a/tests/test_discretisations/test_base_discretisations.py
+++ b/tests/test_discretisations/test_base_discretisations.py
@@ -301,6 +301,7 @@ class TestDiscretise(unittest.TestCase):
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
+        disc.process_model(model)
 
         y0 = model.concatenated_initial_conditions
         np.testing.assert_array_equal(y0, 3 * np.ones_like(combined_submesh.nodes))
@@ -328,7 +329,7 @@ class TestDiscretise(unittest.TestCase):
         }
         model.variables = {"ST": S * T}
 
-        disc.process_model(model, defaults.geometry)
+        disc.process_model(model)
         y0 = model.concatenated_initial_conditions
         np.testing.assert_array_equal(
             y0,
@@ -354,7 +355,7 @@ class TestDiscretise(unittest.TestCase):
         model.boundary_conditions = {}
         model.variables = {"ST": S * T}
         with self.assertRaises(pybamm.ModelError):
-            disc.process_model(model, defaults.geometry)
+            disc.process_model(model)
 
     def test_process_model_dae(self):
         # one rhs equation and one algebraic
@@ -378,6 +379,7 @@ class TestDiscretise(unittest.TestCase):
         disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
+        disc.process_model(model)
         combined_submesh = mesh.combine_submeshes(*whole_cell)
 
         y0 = model.concatenated_initial_conditions
@@ -422,7 +424,7 @@ class TestDiscretise(unittest.TestCase):
         model.variables = {"c": c, "N": N, "d": d}
 
         with self.assertRaises(pybamm.ModelError):
-            disc.process_model(model, defaults.geometry)
+            disc.process_model(model)
 
     def test_broadcast(self):
         whole_cell = ["negative electrode", "separator", "positive electrode"]

--- a/tests/test_discretisations/test_base_discretisations.py
+++ b/tests/test_discretisations/test_base_discretisations.py
@@ -22,10 +22,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
 
         result = disc._concatenate_init(initial_conditions, y_slices)
 
@@ -41,10 +38,7 @@ class TestDiscretise(unittest.TestCase):
     def test_discretise_slicing(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         whole_cell = ["negative electrode", "separator", "positive electrode"]
@@ -78,10 +72,7 @@ class TestDiscretise(unittest.TestCase):
     def test_process_symbol_base(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
 
         # variable
         var = pybamm.Variable("var")
@@ -144,10 +135,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
 
         y_slices = {var1.id: slice(53), var2.id: slice(53, 59)}
         exp_disc = disc.process_symbol(expression, y_slices)
@@ -184,10 +172,7 @@ class TestDiscretise(unittest.TestCase):
     def test_discretise_spatial_operator(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         whole_cell = ["negative electrode", "separator", "positive electrode"]
@@ -230,10 +215,7 @@ class TestDiscretise(unittest.TestCase):
     def test_core_NotImplementedErrors(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
 
         with self.assertRaises(NotImplementedError):
             disc.gradient(None, None, {})
@@ -252,10 +234,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -318,10 +297,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.process_model(model, defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -399,10 +375,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.process_model(model, defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -456,10 +429,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -503,10 +473,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
 
         conc = disc.concatenate(a, b, c)
         self.assertIsInstance(conc, pybamm.NumpyModelConcatenation)
@@ -518,10 +485,7 @@ class TestDiscretise(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         var = pybamm.Variable("var", domain=whole_cell)
@@ -541,10 +505,7 @@ class TestDiscretise(unittest.TestCase):
     def test_discretise_space(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
 
         # space
         x1 = pybamm.Space(["negative electrode"])

--- a/tests/test_discretisations/test_finite_volume_discretisations.py
+++ b/tests/test_discretisations/test_finite_volume_discretisations.py
@@ -38,10 +38,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -96,10 +93,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         # Add ghost nodes
@@ -142,10 +136,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         whole_cell = ["negative electrode", "separator", "positive electrode"]
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -192,10 +183,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         """
         # create discretisation
         defaults = shared.TestDefaults1DParticle(10)
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes("negative particle")
@@ -248,10 +236,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -291,10 +276,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DParticle(10)
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         combined_submesh = mesh.combine_submeshes("negative particle")
@@ -338,10 +320,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         """
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = pybamm.FiniteVolumeDiscretisation(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
         mesh = disc.mesh
 
         mesh.add_ghost_meshes()
@@ -396,12 +375,8 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
             # Set up discretisation
             n = 3 * round(n / 3)
             # create discretisation
-            defaults = shared.TestDefaults1DMacro()
-            defaults.set_equal_pts(n)
-            disc = pybamm.FiniteVolumeDiscretisation(
-                defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-            )
-            disc.mesh_geometry(defaults.geometry)
+            defaults = shared.TestDefaults1DMacro(n)
+            disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
             mesh = disc.mesh
 
             combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -440,12 +415,8 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         # Function for convergence testing
         def get_l2_error(n):
             # create discretisation
-            defaults = shared.TestDefaults1DMacro()
-            defaults.set_equal_pts(n)
-            disc = pybamm.FiniteVolumeDiscretisation(
-                defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-            )
-            disc.mesh_geometry(defaults.geometry)
+            defaults = shared.TestDefaults1DMacro(n)
+            disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
             mesh = disc.mesh
 
             # Set up discretisation
@@ -490,12 +461,8 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         def get_l2_error(n):
 
             # create discretisation
-            defaults = shared.TestDefaults1DMacro()
-            defaults.set_equal_pts(n)
-            disc = pybamm.FiniteVolumeDiscretisation(
-                defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-            )
-            disc.mesh_geometry(defaults.geometry)
+            defaults = shared.TestDefaults1DMacro(n)
+            disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
             mesh = disc.mesh
 
             whole_cell = ["negative electrode", "separator", "positive electrode"]
@@ -538,12 +505,8 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         def get_l2_error(n):
             whole_cell = ["negative electrode", "separator", "positive electrode"]
             # create discretisation
-            defaults = shared.TestDefaults1DMacro()
-            defaults.set_equal_pts(n)
-            disc = pybamm.FiniteVolumeDiscretisation(
-                defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-            )
-            disc.mesh_geometry(defaults.geometry)
+            defaults = shared.TestDefaults1DMacro(n)
+            disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
             mesh = disc.mesh
 
             combined_submesh = mesh.combine_submeshes(*whole_cell)
@@ -585,10 +548,7 @@ class TestFiniteVolumeDiscretisation(unittest.TestCase):
         def get_l2_error(n):
             defaults = shared.TestDefaults1DParticle(n)
 
-            disc = pybamm.FiniteVolumeDiscretisation(
-                defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-            )
-            disc.mesh_geometry(defaults.geometry)
+            disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
             mesh = disc.mesh["negative particle"]
             r = mesh.nodes
 

--- a/tests/test_expression_tree/test_concatenations.py
+++ b/tests/test_expression_tree/test_concatenations.py
@@ -80,10 +80,7 @@ class TestConcatenations(unittest.TestCase):
     def test_numpy_domain_concatenation(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         a_dom = ["negative electrode"]

--- a/tests/test_expression_tree/test_unary_operators.py
+++ b/tests/test_expression_tree/test_unary_operators.py
@@ -76,10 +76,7 @@ class TestUnaryOperators(unittest.TestCase):
     def test_numpy_broadcast(self):
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.mesh_geometry(defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
         mesh = disc.mesh
 
         whole_cell = ["negative electrode", "separator", "positive electrode"]

--- a/tests/test_models/standard_model_tests.py
+++ b/tests/test_models/standard_model_tests.py
@@ -27,7 +27,7 @@ class StandardModelTest(object):
         # Overwrite discretisation if given
         if disc is not None:
             self.disc = disc
-        self.disc.process_model(self.model, self.geometry)
+        self.disc.process_model(self.model)
         # Model should still be well-posed after processing
         self.model.check_well_posedness()
 

--- a/tests/test_models/test_interface.py
+++ b/tests/test_models/test_interface.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
+import tests.shared as shared
 
 import unittest
 
@@ -49,31 +50,15 @@ class TestHomogeneousReaction(unittest.TestCase):
         self.assertEqual(processed_rxn.children[2].evaluate() * lp.evaluate(), -1)
 
     def test_discretisation(self):
-        whole_cell = ["negative electrode", "separator", "positive electrode"]
-        param = pybamm.ParameterValues(
-            "input/parameters/lithium-ion/parameters/LCO.csv"
-        )
-        geometry = pybamm.Geometry1DMacro()
-        param.process_geometry(geometry)
+        defaults = shared.TestDefaults1DMacro()
+        disc = pybamm.FiniteVolumeDiscretisation(defaults.mesh)
 
-        mesh_type = pybamm.Mesh
-        submesh_pts = {
-            "negative electrode": {"x": 40},
-            "separator": {"x": 25},
-            "positive electrode": {"x": 35},
-        }
-        submesh_types = {
-            "negative electrode": pybamm.Uniform1DSubMesh,
-            "separator": pybamm.Uniform1DSubMesh,
-            "positive electrode": pybamm.Uniform1DSubMesh,
-        }
-
-        disc = pybamm.FiniteVolumeDiscretisation(mesh_type, submesh_pts, submesh_types)
-        disc._mesh = mesh_type(geometry, submesh_types, submesh_pts)
         rxn = pybamm.interface.homogeneous_reaction()
 
-        param_rxn = param.process_symbol(rxn)
+        param_rxn = defaults.param.process_symbol(rxn)
         processed_rxn = disc.process_symbol(param_rxn)
+
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
 
         combined_submeshes = disc.mesh.combine_submeshes(*whole_cell)
         # processed_rxn should be a vector with the right shape

--- a/tests/test_models/test_lead_acid.py
+++ b/tests/test_models/test_lead_acid.py
@@ -23,7 +23,7 @@ class TestLeadAcidLOQS(unittest.TestCase):
         # process parameter values, discretise and solve
         model.default_parameter_values.process_model(model)
         disc = model.default_discretisation
-        disc.process_model(model, model.default_geometry)
+        disc.process_model(model)
         t_eval = np.linspace(0, 1, 100)
         solver = model.default_solver
         solver.solve(model, t_eval)

--- a/tests/test_models/test_simple_ode_model.py
+++ b/tests/test_models/test_simple_ode_model.py
@@ -23,9 +23,8 @@ class TestSimpleODEModel(unittest.TestCase):
 
         # discretise and solve
         disc = model.default_discretisation
-        disc.mesh_geometry(model.default_geometry)
         combined_submesh = disc.mesh.combine_submeshes(*whole_cell)
-        disc.process_model(model, model.default_geometry)
+        disc.process_model(model)
         t_eval = np.linspace(0, 1, 100)
         solver = model.default_solver
         solver.solve(model, t_eval)

--- a/tests/test_solvers/test_scikits_solvers.py
+++ b/tests/test_solvers/test_scikits_solvers.py
@@ -74,7 +74,7 @@ class TestScikitsSolver(unittest.TestCase):
         model.initial_conditions = {var: 1}
         model.initial_conditions_ydot = {var: 0.1}
         disc = model.default_discretisation
-        disc.process_model(model, model.default_geometry)
+        disc.process_model(model)
 
         # Solve
         solver = pybamm.ScikitsOdeSolver(tol=1e-9)
@@ -94,7 +94,7 @@ class TestScikitsSolver(unittest.TestCase):
         model.initial_conditions = {var1: 1, var2: 2}
         model.initial_conditions_ydot = {var1: 0.1, var2: 0.2}
         disc = model.default_discretisation
-        disc.process_model(model, model.default_geometry)
+        disc.process_model(model)
 
         # Solve
         solver = pybamm.ScikitsDaeSolver(tol=1e-8)

--- a/tests/test_solvers/test_scipy_solver.py
+++ b/tests/test_solvers/test_scipy_solver.py
@@ -46,10 +46,8 @@ class TestScipySolver(unittest.TestCase):
 
         # create discretisation
         defaults = shared.TestDefaults1DMacro()
-        disc = shared.DiscretisationForTesting(
-            defaults.mesh_type, defaults.submesh_pts, defaults.submesh_types
-        )
-        disc.process_model(model, defaults.geometry)
+        disc = shared.DiscretisationForTesting(defaults.mesh)
+        disc.process_model(model)
         # Solve
         solver = pybamm.ScipySolver(tol=1e-8, method="RK45")
         t_eval = np.linspace(0, 1, 100)


### PR DESCRIPTION
# Description

Mesh moved outside of discretisation and tests corrected

Fixes #133 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
