### PR TITLE
Issue 111 integral node

### DIFF
--- a/docs/source/expression_tree/unary_operator.rst
+++ b/docs/source/expression_tree/unary_operator.rst
@@ -25,9 +25,6 @@ Unary Operators
 .. autoclass:: pybamm.Integral
   :members:
 
-.. autoclass:: pybamm.IndefiniteIntegral
-  :members:
-
 .. autofunction:: pybamm.grad
 
 .. autofunction:: pybamm.div

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -78,7 +78,6 @@ from .expression_tree.unary_operators import (
     Divergence,
     SurfaceValue,
     Integral,
-    IndefiniteIntegral,
     grad,
     div,
     surf,

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -219,8 +219,10 @@ class Discretisation(object):
             )
 
         elif isinstance(symbol, pybamm.Integral):
-            return self.integral(
-                symbol.children[0], y_slices, boundary_conditions, symbol.definite
+            child = symbol.children[0]
+            discretised_child = self.process_symbol(child)
+            return self._spatial_methods[symbol.domain[0]].integral(
+                child, discretised_child
             )
 
         elif isinstance(symbol, pybamm.Broadcast):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -146,15 +146,11 @@ class Integral(SpatialOperator):
         The function to be integrated (will become self.children[0])
     integration_variable : :class:`pybamm.IndependentVariable`
         The variable over which to integrate
-    definite : boolean, optional
-        Whether the integral is definite or indefinite. If definite, the resulting
-        integral has one dimension fewer than the integrand; if indefinite, the
-        resulting integral has the same shape as the integrand. Default is definite.
 
     **Extends:** :class:`SpatialOperator`
     """
 
-    def __init__(self, child, integration_variable, definite=True):
+    def __init__(self, child, integration_variable):
         if isinstance(integration_variable, pybamm.Space):
             # Check that child and integration_variable domains agree
             if child.domain != integration_variable.domain:
@@ -171,29 +167,12 @@ class Integral(SpatialOperator):
         name = "integral d{}".format(
             integration_variable.name, integration_variable.domain
         )
-        if not definite:
-            name = "indefinite " + name
         super().__init__(name, child)
         self._integration_variable = integration_variable
-        self._definite = definite
 
     @property
     def integration_variable(self):
         return self._integration_variable
-
-    @property
-    def definite(self):
-        return self._definite
-
-
-class IndefiniteIntegral(Integral):
-    """A node in the expression tree representing an indefinite integral operator.
-
-    **Extends:** :class:`Integral`
-    """
-
-    def __init__(self, child, integration_variable):
-        super().__init__(child, integration_variable, definite=False)
 
 
 class SurfaceValue(SpatialOperator):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -151,7 +151,7 @@ class Integral(SpatialOperator):
     """
 
     def __init__(self, child, integration_variable):
-        if isinstance(integration_variable, pybamm.Space):
+        if isinstance(integration_variable, pybamm.SpatialVariable):
             # Check that child and integration_variable domains agree
             if child.domain != integration_variable.domain:
                 raise pybamm.DomainError(
@@ -164,9 +164,9 @@ class Integral(SpatialOperator):
                     type(integration_variable)
                 )
             )
-        name = "integral d{}".format(
-            integration_variable.name, integration_variable.domain
-        )
+        name = "integral d{}".format(integration_variable.name)
+        if isinstance(integration_variable, pybamm.SpatialVariable):
+            name += " {}".format(integration_variable.domain)
         super().__init__(name, child)
         self._integration_variable = integration_variable
 

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -67,7 +67,7 @@ class SpatialMethod:
         ----------
         symbol: :class:`pybamm.Symbol`
             The symbol that we will take the gradient of.
-        broadcasted_symbol: class: pybamm.Array
+        discretised_symbol: class: pybamm.Array
             The discretised symbol of the correct size
 
         boundary_conditions : dict
@@ -82,7 +82,7 @@ class SpatialMethod:
         """
         raise NotImplementedError
 
-    def divergence(self, symbol, broadcasted_symbol, boundary_conditions):
+    def divergence(self, symbol, discretised_symbol, boundary_conditions):
         """
         Implements the divergence for a spatial method.
 
@@ -90,16 +90,35 @@ class SpatialMethod:
         ----------
         symbol: :class:`pybamm.Symbol`
             The symbol that we will take the gradient of.
-        broadcasted_symbol: class: pybamm.Array
+        discretised_symbol: class: pybamm.Array
             The discretised symbol of the correct size
-
         boundary_conditions : dict
             The boundary conditions of the model
             ({symbol.id: {"left": left bc, "right": right bc}})
+
         Returns
         -------
         :class: `pybamm.Array`
             Contains the result of acting the discretised divergence on
+            the child discretised_symbol
+        """
+        raise NotImplementedError
+
+    def integral(self, symbol, discretised_symbol):
+        """
+        Implements the integral for a spatial method.
+
+        Parameters
+        ----------
+        symbol: :class:`pybamm.Symbol`
+            The symbol that we will take the gradient of.
+        discretised_symbol: class: pybamm.Array
+            The discretised symbol of the correct size
+
+        Returns
+        -------
+        :class: `pybamm.Array`
+            Contains the result of acting the discretised integral on
             the child discretised_symbol
         """
         raise NotImplementedError

--- a/tests/test_discretisations/test_discretisation.py
+++ b/tests/test_discretisations/test_discretisation.py
@@ -236,14 +236,14 @@ class TestDiscretise(unittest.TestCase):
 
     def test_core_NotImplementedErrors(self):
         # create discretisation
-        pybamm.Discretisation(None, {})
+        disc = pybamm.Discretisation(None, {})
 
         with self.assertRaises(NotImplementedError):
             disc.gradient(None, None, {})
         with self.assertRaises(NotImplementedError):
             disc.divergence(None, None, {})
         with self.assertRaises(NotImplementedError):
-            disc.integral(None, None, {})
+            disc.integral(None, None)
 
     def test_process_dict(self):
         # one equation

--- a/tests/test_discretisations/test_discretisation.py
+++ b/tests/test_discretisations/test_discretisation.py
@@ -235,15 +235,15 @@ class TestDiscretise(unittest.TestCase):
             )
 
     def test_core_NotImplementedErrors(self):
-        # create discretisation
-        disc = pybamm.Discretisation(None, {})
+        # create spatial method
+        spatial_method = pybamm.SpatialMethod(None)
 
         with self.assertRaises(NotImplementedError):
-            disc.gradient(None, None, {})
+            spatial_method.gradient(None, None, {})
         with self.assertRaises(NotImplementedError):
-            disc.divergence(None, None, {})
+            spatial_method.divergence(None, None, {})
         with self.assertRaises(NotImplementedError):
-            disc.integral(None, None)
+            spatial_method.integral(None, None)
 
     def test_process_dict(self):
         # one equation

--- a/tests/test_expression_tree/test_unary_operators.py
+++ b/tests/test_expression_tree/test_unary_operators.py
@@ -78,9 +78,9 @@ class TestUnaryOperators(unittest.TestCase):
 
         # space integral
         a = pybamm.Symbol("a", domain=["negative electrode"])
-        x = pybamm.Space(["negative electrode"])
+        x = pybamm.SpatialVariable("x", ["negative electrode"])
         inta = pybamm.Integral(a, x)
-        self.assertEqual(inta.name, "integral dspace (['negative electrode'])")
+        self.assertEqual(inta.name, "integral dx ['negative electrode']")
         self.assertEqual(inta.children[0].name, a.name)
         self.assertEqual(inta.integration_variable, x)
         self.assertEqual(inta.domain, ["negative electrode"])
@@ -100,7 +100,7 @@ class TestUnaryOperators(unittest.TestCase):
 
         # expected errors
         a = pybamm.Symbol("a", domain=["negative electrode"])
-        x = pybamm.Space(["separator"])
+        x = pybamm.SpatialVariable("x", ["separator"])
         y = pybamm.Variable("y")
         with self.assertRaises(pybamm.DomainError):
             pybamm.Integral(a, x)

--- a/tests/test_expression_tree/test_unary_operators.py
+++ b/tests/test_expression_tree/test_unary_operators.py
@@ -71,7 +71,7 @@ class TestUnaryOperators(unittest.TestCase):
         t = pybamm.t
         inta = pybamm.Integral(a, t)
         self.assertEqual(inta.name, "integral dtime")
-        self.assertTrue(inta.definite)
+        # self.assertTrue(inta.definite)
         self.assertEqual(inta.children[0].name, a.name)
         self.assertEqual(inta.integration_variable, t)
         self.assertEqual(inta.domain, [])

--- a/tests/test_spatial_methods/test_finite_volume.py
+++ b/tests/test_spatial_methods/test_finite_volume.py
@@ -404,7 +404,7 @@ class TestFiniteVolume(unittest.TestCase):
 
     def test_definite_integral(self):
         # create discretisation
-        mesh = get_mesh_for_testing()
+        mesh = get_mesh_for_testing(200)
         spatial_methods = {
             "macroscale": pybamm.FiniteVolume,
             "negative particle": pybamm.FiniteVolume,
@@ -418,11 +418,10 @@ class TestFiniteVolume(unittest.TestCase):
 
         # macroscale variable
         var = pybamm.Variable("var", domain=["negative electrode", "separator"])
-        integral_eqn = pybamm.Integral(
-            var, pybamm.Space(["negative electrode", "separator"])
-        )
-        y_slices = disc.get_variable_slices([var])
-        integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
+        x = pybamm.SpatialVariable("x", ["negative electrode", "separator"])
+        integral_eqn = pybamm.Integral(var, x)
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
 
         combined_submesh = mesh.combine_submeshes("negative electrode", "separator")
         constant_y = np.ones_like(combined_submesh.nodes)
@@ -438,11 +437,10 @@ class TestFiniteVolume(unittest.TestCase):
 
         # domain not starting at zero
         var = pybamm.Variable("var", domain=["separator", "positive electrode"])
-        integral_eqn = pybamm.Integral(
-            var, pybamm.Space(["separator", "positive electrode"])
-        )
-        y_slices = disc.get_variable_slices([var])
-        integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
+        x = pybamm.SpatialVariable("x", ["separator", "positive electrode"])
+        integral_eqn = pybamm.Integral(var, x)
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
 
         combined_submesh = mesh.combine_submeshes("separator", "positive electrode")
         constant_y = np.ones_like(combined_submesh.nodes)
@@ -458,9 +456,10 @@ class TestFiniteVolume(unittest.TestCase):
 
         # microscale variable
         var = pybamm.Variable("var", domain=["negative particle"])
-        integral_eqn = pybamm.Integral(var, pybamm.Space(["negative particle"]))
-        y_slices = disc.get_variable_slices([var])
-        integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
+        r = pybamm.SpatialVariable("r", ["negative particle"])
+        integral_eqn = pybamm.Integral(var, r)
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
 
         constant_y = np.ones_like(mesh["negative particle"].nodes)
         self.assertEqual(integral_eqn_disc.evaluate(None, constant_y), np.pi)
@@ -486,11 +485,10 @@ class TestFiniteVolume(unittest.TestCase):
 
         # macroscale variable
         var = pybamm.Variable("var", domain=["negative electrode", "separator"])
-        integral_eqn = pybamm.IndefiniteIntegral(
-            var, pybamm.Space(["negative electrode", "separator"])
-        )
-        y_slices = disc.get_variable_slices([var])
-        integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
+        x = pybamm.SpatialVariable("x", ["negative electrode", "separator"])
+        integral_eqn = pybamm.IndefiniteIntegral(var, x)
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
 
         combined_submesh = mesh.combine_submeshes("negative electrode", "separator")
         constant_y = np.ones_like(combined_submesh.nodes)
@@ -511,11 +509,10 @@ class TestFiniteVolume(unittest.TestCase):
 
         # domain not starting at zero
         var = pybamm.Variable("var", domain=["separator", "positive electrode"])
-        integral_eqn = pybamm.IndefiniteIntegral(
-            var, pybamm.Space(["separator", "positive electrode"])
-        )
-        y_slices = disc.get_variable_slices([var])
-        integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
+        x = pybamm.SpatialVariable("x", ["separator", "positive electrode"])
+        integral_eqn = pybamm.IndefiniteIntegral(var, x)
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
 
         combined_submesh = mesh.combine_submeshes("separator", "positive electrode")
         np.testing.assert_array_equal(
@@ -533,11 +530,10 @@ class TestFiniteVolume(unittest.TestCase):
 
         # microscale variable
         var = pybamm.Variable("var", domain=["negative particle"])
-        integral_eqn = pybamm.IndefiniteIntegral(
-            var, pybamm.Space(["negative particle"])
-        )
-        y_slices = disc.get_variable_slices([var])
-        integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
+        r = pybamm.SpatialVariable("r", ["negative particle"])
+        integral_eqn = pybamm.IndefiniteIntegral(var, r)
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
 
         constant_y = np.ones_like(mesh["negative particle"].nodes)
         np.testing.assert_array_equal(

--- a/tests/test_spatial_methods/test_finite_volume.py
+++ b/tests/test_spatial_methods/test_finite_volume.py
@@ -474,11 +474,15 @@ class TestFiniteVolume(unittest.TestCase):
     @unittest.skip("indefinite integral not yet implemented")
     def test_indefinite_integral(self):
         # create discretisation
-        mesh = shared.TestDefaults1DMacro().mesh
-        disc = pybamm.FiniteVolumeDiscretisation(mesh)
+        mesh = get_mesh_for_testing()
+        spatial_methods = {
+            "macroscale": pybamm.FiniteVolume,
+            "negative particle": pybamm.FiniteVolume,
+            "positive particle": pybamm.FiniteVolume,
+        }
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        # lengths
         ln = mesh["negative electrode"].edges[-1]
-        ls = mesh["separator"].edges[-1] - ln
-        lp = 1 - (ln + ls)
 
         # macroscale variable
         var = pybamm.Variable("var", domain=["negative electrode", "separator"])
@@ -489,6 +493,7 @@ class TestFiniteVolume(unittest.TestCase):
         integral_eqn_disc = disc.process_symbol(integral_eqn, y_slices)
 
         combined_submesh = mesh.combine_submeshes("negative electrode", "separator")
+        constant_y = np.ones_like(combined_submesh.nodes)
         constant_y_edges = np.ones_like(combined_submesh.edges)
         linear_y = combined_submesh.nodes
         linear_y_edges = combined_submesh.edges
@@ -527,8 +532,6 @@ class TestFiniteVolume(unittest.TestCase):
         )
 
         # microscale variable
-        mesh = shared.TestDefaults1DParticle(200).mesh
-        disc = pybamm.FiniteVolumeDiscretisation(mesh)
         var = pybamm.Variable("var", domain=["negative particle"])
         integral_eqn = pybamm.IndefiniteIntegral(
             var, pybamm.Space(["negative particle"])


### PR DESCRIPTION
# Description

Node to calculate the definite integral, needed for some of the reduced-order models
Fixes #111 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
