### PR TITLE
Issue 189 symbolic differentiation

### DIFF
--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -6,6 +6,7 @@ from __future__ import print_function, unicode_literals
 import pybamm
 
 import numbers
+import numpy as np
 
 
 class BinaryOperator(pybamm.Symbol):
@@ -69,6 +70,18 @@ class Power(BinaryOperator):
         """ See :meth:`pybamm.BinaryOperator.__init__()`. """
         super().__init__("**", left, right)
 
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            # apply chain rule and power rule
+            base, exponent = self.orphans
+            return base ** (exponent - 1) * (
+                exponent * base.diff(variable)
+                + base * pybamm.Function(np.log, base) * exponent.diff(variable)
+            )
+
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
         return self.children[0].evaluate(t, y) ** self.children[1].evaluate(t, y)
@@ -83,6 +96,13 @@ class Addition(BinaryOperator):
     def __init__(self, left, right):
         """ See :meth:`pybamm.BinaryOperator.__init__()`. """
         super().__init__("+", left, right)
+
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            return self.children[0].diff(variable) + self.children[1].diff(variable)
 
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
@@ -100,6 +120,13 @@ class Subtraction(BinaryOperator):
 
         super().__init__("-", left, right)
 
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            return self.children[0].diff(variable) - self.children[1].diff(variable)
+
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
         return self.children[0].evaluate(t, y) - self.children[1].evaluate(t, y)
@@ -115,6 +142,15 @@ class Multiplication(BinaryOperator):
         """ See :meth:`pybamm.BinaryOperator.__init__()`. """
 
         super().__init__("*", left, right)
+
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            # apply product rule
+            left, right = self.orphans
+            return left.diff(variable) * right + left * right.diff(variable)
 
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
@@ -132,6 +168,11 @@ class MatrixMultiplication(BinaryOperator):
 
         super().__init__("*", left, right)
 
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        # We shouldn't need this
+        raise NotImplementedError
+
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
         return self.children[0].evaluate(t, y) @ self.children[1].evaluate(t, y)
@@ -146,6 +187,17 @@ class Division(BinaryOperator):
     def __init__(self, left, right):
         """ See :meth:`pybamm.BinaryOperator.__init__()`. """
         super().__init__("/", left, right)
+
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            # apply quotient rule
+            top, bottom = self.orphans
+            return (
+                top.diff(variable) * bottom - top * bottom.diff(variable)
+            ) / bottom ** 2
 
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -6,7 +6,7 @@ from __future__ import print_function, unicode_literals
 import pybamm
 
 import numbers
-import numpy as np
+import autograd.numpy as np
 
 
 class BinaryOperator(pybamm.Symbol):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -296,6 +296,23 @@ class Symbol(anytree.NodeMixin):
         """return an :class:`AbsoluteValue` object"""
         return pybamm.AbsoluteValue(self)
 
+    def diff(self, variable):
+        """
+        Differentiate a symbol with respect to a variable. Default behaviour is to
+        return `1` if differentiating with respect to yourself and zero otherwise.
+        Binary and Unary Operators override this.
+
+        Parameters
+        ----------
+        variable : :class:`pybamm.Symbol`
+            The variable with respect to which to differentiate
+
+        """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            return pybamm.Scalar(0)
+
     def evaluate(self, t=None, y=None):
         """evaluate expression tree
 

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -96,8 +96,12 @@ class Function(UnaryOperator):
         if variable.id == self.id:
             return pybamm.Scalar(1)
         else:
-            # use autograd to differentiate function
-            return Function(autograd.grad(self.func), self.orphans[0])
+            child = self.orphans[0]
+            if variable.id in [symbol.id for symbol in child.pre_order()]:
+                # use autograd to differentiate function, and apply chain rule
+                return child.diff(variable) * Function(autograd.grad(self.func), child)
+            else:
+                return pybamm.Scalar(0)
 
     def evaluate(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -98,9 +98,11 @@ class Function(UnaryOperator):
         else:
             child = self.orphans[0]
             if variable.id in [symbol.id for symbol in child.pre_order()]:
-                # use autograd to differentiate function, and apply chain rule
+                # if variable appears in the function,use autograd to differentiate
+                # function, and apply chain rule
                 return child.diff(variable) * Function(autograd.grad(self.func), child)
             else:
+                # otherwise the derivative of the function is zero
                 return pybamm.Scalar(0)
 
     def evaluate(self, t=None, y=None):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -46,6 +46,13 @@ class Negate(UnaryOperator):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
         return -self.children[0].evaluate(t, y)
 
+    def diff(self, variable):
+        """ See :meth:`pybamm.Symbol.diff()`. """
+        if variable.id == self.id:
+            return pybamm.Scalar(1)
+        else:
+            return -self.children[0].diff(variable)
+
     def __str__(self):
         """ See :meth:`pybamm.Symbol.__str__()`. """
         return "{}{!s}".format(self.name, self.children[0])

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "pandas>=0.23",
         "anytree>=2.4.3",
         "autograd>=1.2",
-        # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
+        # Note: Matplotlib is loaded for debug plots, but to ensure pybamm runs
         # on systems without an attached display, it should never be imported
         # outside of plot() methods.
         # Should not be imported

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "scipy>=1.0",
         "pandas>=0.23",
         "anytree>=2.4.3",
+        "autograd>=1.2",
         # Note: Matplotlib is loaded for debug plots, but to ensure pints runs
         # on systems without an attached display, it should never be imported
         # outside of plot() methods.
@@ -27,10 +28,7 @@ setup(
         "matplotlib>=2.0",
     ],
     extras_require={
-        "docs": [
-            "sphinx>=1.5",
-            "guzzle-sphinx-theme",
-        ],  # For doc generation
+        "docs": ["sphinx>=1.5", "guzzle-sphinx-theme"],  # For doc generation
         "dev": [
             "flake8>=3",  # For code style checking
             "jupyter",  # For documentation and testing

--- a/tests/test_expression_tree/test_symbol.py
+++ b/tests/test_expression_tree/test_symbol.py
@@ -118,6 +118,14 @@ class TestSymbol(unittest.TestCase):
         for node, expect in zip(exp.pre_order(), expected_preorder):
             self.assertEqual(node.name, expect)
 
+    def test_symbol_diff(self):
+        a = pybamm.Symbol("a")
+        b = pybamm.Symbol("b")
+        self.assertIsInstance(a.diff(a), pybamm.Scalar)
+        self.assertEqual(a.diff(a).evaluate(), 1)
+        self.assertIsInstance(a.diff(b), pybamm.Scalar)
+        self.assertEqual(a.diff(b).evaluate(), 0)
+
     def test_symbol_evaluation(self):
         a = pybamm.Symbol("a")
         with self.assertRaises(NotImplementedError):

--- a/tests/test_expression_tree/test_symbolic_diff.py
+++ b/tests/test_expression_tree/test_symbolic_diff.py
@@ -1,0 +1,66 @@
+#
+# Tests for the symbolic differentiation methods
+#
+from __future__ import absolute_import, division
+from __future__ import print_function, unicode_literals
+import pybamm
+
+import autograd.numpy as np
+import unittest
+
+
+class TestSymbolicDifferentiation(unittest.TestCase):
+    def test_advanced(self):
+        a = pybamm.StateVector(slice(0, 1))
+        b = pybamm.StateVector(slice(1, 2))
+        y = np.array([5, 3])
+
+        #
+        func = (a * 2 + 5 * (-b)) / (a * b)
+        self.assertEqual(func.diff(a).evaluate(y=y), 1 / 5)
+        self.assertEqual(func.diff(b).evaluate(y=y), -2 / 9)
+        #
+        func = a * b ** a
+        self.assertAlmostEqual(
+            func.diff(a).evaluate(y=y)[0], 3 ** 5 * (5 * np.log(3) + 1)
+        )
+        self.assertEqual(func.diff(b).evaluate(y=y), 5 ** 2 * 3 ** 4)
+
+    def test_advanced_functions(self):
+        a = pybamm.StateVector(slice(0, 1))
+        b = pybamm.StateVector(slice(1, 2))
+        y = np.array([5, 3])
+
+        #
+        func = a * pybamm.Function(np.exp, b)
+        self.assertAlmostEqual(func.diff(a).evaluate(y=y)[0], np.exp(3))
+        func = pybamm.Function(np.exp, a + 2 * b + a * b) + a * pybamm.Function(
+            np.exp, b
+        )
+        self.assertEqual(
+            func.diff(a).evaluate(y=y), (4 * np.exp(3 * 5 + 5 + 2 * 3) + np.exp(3))
+        )
+        self.assertEqual(
+            func.diff(b).evaluate(y=y), np.exp(3) * (7 * np.exp(3 * 5 + 5 + 3) + 5)
+        )
+        #
+        func = pybamm.Function(
+            np.sin, pybamm.Function(np.cos, a * 4) / 2
+        ) * pybamm.Function(np.cos, 4 * pybamm.Function(np.exp, b / 3))
+        self.assertEqual(
+            func.diff(a).evaluate(y=y),
+            -2 * np.sin(20) * np.cos(np.cos(20) / 2) * np.cos(4 * np.exp(1)),
+        )
+        self.assertEqual(
+            func.diff(b).evaluate(y=y),
+            -4 / 3 * np.exp(1) * np.sin(4 * np.exp(1)) * np.sin(np.cos(20) / 2),
+        )
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    unittest.main()

--- a/tests/test_expression_tree/test_unary_operators.py
+++ b/tests/test_expression_tree/test_unary_operators.py
@@ -7,6 +7,7 @@ import pybamm
 
 import unittest
 import numpy as np
+import autograd.numpy as auto_np
 
 
 def test_function(arg):
@@ -106,6 +107,35 @@ class TestUnaryOperators(unittest.TestCase):
             pybamm.Integral(a, x)
         with self.assertRaises(ValueError):
             pybamm.Integral(a, y)
+
+    def test_diff(self):
+        a = pybamm.StateVector(slice(0, 1))
+        y = np.array([5])
+
+        # negation
+        self.assertEqual((-a).diff(a).evaluate(y=y), -1)
+        self.assertEqual((-a).diff(-a).evaluate(), 1)
+
+        # absolute value (not implemented)
+        absa = abs(a)
+        with self.assertRaises(NotImplementedError):
+            absa.diff(a)
+
+        # function: use autograd
+        func = pybamm.Function(test_function, a)
+        self.assertEqual((func).diff(a).evaluate(y=y), 2)
+        self.assertEqual((func).diff(func).evaluate(), 1)
+        func = pybamm.Function(auto_np.sin, a)
+        self.assertEqual(func.evaluate(y=y), np.sin(a.evaluate(y=y)))
+        self.assertEqual(func.diff(a).evaluate(y=y), np.cos(a.evaluate(y=y)))
+        func = pybamm.Function(auto_np.exp, a)
+        self.assertEqual(func.evaluate(y=y), np.exp(a.evaluate(y=y)))
+        self.assertEqual(func.diff(a).evaluate(y=y), np.exp(a.evaluate(y=y)))
+
+        # spatial operator (not implemented)
+        spatial_a = pybamm.SpatialOperator("name", a)
+        with self.assertRaises(NotImplementedError):
+            spatial_a.diff(a)
 
     def test_printing(self):
         a = pybamm.Symbol("a")


### PR DESCRIPTION
# Description

Implement symbolic differentiation using simple calculus rules and autograd for the `Function` objects.
Requires implementing functions using `autograd.numpy` instead of `numpy`.
Fixes #189 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
