### PR TITLE
Issue 215 mass matrix

### DIFF
--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -7,6 +7,7 @@ import pybamm
 
 import copy
 import numpy as np
+from scipy.sparse import block_diag, csr_matrix
 
 
 class Discretisation(object):
@@ -74,6 +75,9 @@ class Discretisation(object):
         for idx, event in enumerate(model.events):
             model.events[idx] = self.process_symbol(event)
         model.concatenated_events = self.concatenate(*model.events)
+
+        # Process mass matrix
+        self.process_mass_matrix(model)
 
         # Check that resulting model makes sense
         self.check_model(model)
@@ -150,6 +154,43 @@ class Discretisation(object):
         # Discretise and concatenate algebraic equations
         model.algebraic = self.process_dict(model.algebraic)
         model.concatenated_algebraic = self.concatenate(*model.algebraic.values())
+
+    def process_mass_matrix(self, model):
+        """Creates mass matrix of the discretised model.
+
+        Parameters
+        ----------
+        model : :class:`pybamm.BaseModel` (or subclass)
+            Model to dicretise. Must have attributes rhs, initial_conditions and
+            boundary_conditions (all dicts of {variable: equation})
+        """
+        # Create list of mass matrices for each equation to be put into block
+        # diagonal mass matrix for the model
+        mass_list = []
+
+        # Process mass matrices for the differential equations
+        for var in model.rhs.keys():
+            if var.domain == []:
+                # If variable domain empty then mass matrix is just 1
+                mass_list.append(1.0)
+            else:
+                mass_list.append(
+                    self._spatial_methods[var.domain[0]]
+                    .mass_matrix(var, self._bcs)
+                    .entries
+                )
+
+        # Create lumped mass matrix (of zeros) of the correct shape for the
+        # discretised algebraic equations
+        if model.algebraic.keys():
+            y0 = model.concatenated_initial_conditions
+            mass_algebraic_size = model.concatenated_algebraic.evaluate(0, y0).shape[0]
+            mass_algebraic = csr_matrix((mass_algebraic_size, mass_algebraic_size))
+            mass_list.append(mass_algebraic)
+
+        # Create block diagonal (sparse) mass matrix
+        mass_matrix = block_diag(mass_list)
+        model.mass_matrix = pybamm.Matrix(mass_matrix)
 
     def process_dict(self, var_eqn_dict):
         """Discretise a dictionary of {variable: equation}, broadcasting if necessary

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -78,8 +78,8 @@ class Discretisation(object):
             model.events[idx] = self.process_symbol(event)
         model.concatenated_events = self.concatenate(*model.events)
 
-        # Process mass matrix
-        self.process_mass_matrix(model)
+        # Create mass matrix
+        self.create_mass_matrix(model)
 
         # Check that resulting model makes sense
         self.check_model(model)
@@ -158,7 +158,7 @@ class Discretisation(object):
         model.algebraic = self.process_dict(model.algebraic)
         model.concatenated_algebraic = self.concatenate(*model.algebraic.values())
 
-    def process_mass_matrix(self, model):
+    def create_mass_matrix(self, model):
         """Creates mass matrix of the discretised model.
 
         Parameters

--- a/pybamm/models/base_models.py
+++ b/pybamm/models/base_models.py
@@ -50,6 +50,7 @@ class BaseModel(object):
         self._events = []
         self._concatenated_rhs = None
         self._concatenated_initial_conditions = None
+        self._mass_matrix = None
 
         # Default parameter values, geometry, submesh, spatial methods and solver
         input_path = os.path.join(
@@ -189,6 +190,14 @@ class BaseModel(object):
     @concatenated_initial_conditions.setter
     def concatenated_initial_conditions(self, concatenated_initial_conditions):
         self._concatenated_initial_conditions = concatenated_initial_conditions
+
+    @property
+    def mass_matrix(self):
+        return self._mass_matrix
+
+    @mass_matrix.setter
+    def mass_matrix(self, mass_matrix):
+        self._mass_matrix = mass_matrix
 
     def __getitem__(self, key):
         return self.rhs[key]

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -94,7 +94,7 @@ class DaeSolver(pybamm.BaseSolver):
 
         return y0_consistent
 
-    def integrate(self, residuals, y0, t_eval, events=None):
+    def integrate(self, residuals, y0, t_eval, events=None, mass_matrix=None):
         """
         Solve a DAE model defined by residuals with initial conditions y0.
 
@@ -110,6 +110,7 @@ class DaeSolver(pybamm.BaseSolver):
         events : method, optional
             A function that takes in t and y and returns conditions for the solver to
             stop
-
+        mass_matrix : array_like
+            The (sparse) mass matrix for the chosen spatial method.
         """
         raise NotImplementedError

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -40,7 +40,7 @@ class OdeSolver(pybamm.BaseSolver):
         y0 = model.concatenated_initial_conditions
         self.t, self.y = self.integrate(dydt, y0, t_eval, events=events)
 
-    def integrate(self, derivs, y0, t_eval, events=None):
+    def integrate(self, derivs, y0, t_eval, events=None, mass_matrix=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -55,6 +55,7 @@ class OdeSolver(pybamm.BaseSolver):
         events : method, optional
             A function that takes in t and y and returns conditions for the solver to
             stop
-
+        mass_matrix : :class:`pybamm.Matrix`
+            The (sparse) mass matrix for the chosen spatial method.
         """
         raise NotImplementedError

--- a/pybamm/solvers/scikits_dae_solver.py
+++ b/pybamm/solvers/scikits_dae_solver.py
@@ -43,7 +43,7 @@ class ScikitsDaeSolver(pybamm.DaeSolver):
     def method(self, value):
         self._method = value
 
-    def integrate(self, residuals, y0, t_eval, events=None):
+    def integrate(self, residuals, y0, t_eval, events=None, mass_matrix=None):
         """
         Solve a DAE model defined by residuals with initial conditions y0.
 
@@ -59,7 +59,8 @@ class ScikitsDaeSolver(pybamm.DaeSolver):
         events : method, optional
             A function that takes in t and y and returns conditions for the solver to
             stop
-
+        mass_matrix : array_like
+            The (sparse) mass matrix for the chosen spatial method.
         """
 
         def eqsres(t, y, ydot, return_residuals):

--- a/pybamm/solvers/scikits_ode_solver.py
+++ b/pybamm/solvers/scikits_ode_solver.py
@@ -43,7 +43,7 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
     def method(self, value):
         self._method = value
 
-    def integrate(self, derivs, y0, t_eval, events=None):
+    def integrate(self, derivs, y0, t_eval, events=None, mass_matrix=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -58,6 +58,8 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
         events : method, optional
             A function that takes in t and y and returns conditions for the solver to
             stop
+        mass_matrix : array_like
+            The (sparse) mass matrix for the chosen spatial method.
 
         """
 

--- a/pybamm/solvers/scipy_solver.py
+++ b/pybamm/solvers/scipy_solver.py
@@ -32,7 +32,7 @@ class ScipySolver(pybamm.OdeSolver):
     def method(self, value):
         self._method = value
 
-    def integrate(self, derivs, y0, t_eval, events=None):
+    def integrate(self, derivs, y0, t_eval, events=None, mass_matrix=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -48,6 +48,8 @@ class ScipySolver(pybamm.OdeSolver):
         events : method, optional
             A function that takes in t and y and returns conditions for the solver to
             stop
+        mass_matrix : array_like
+            The (sparse) mass matrix for the chosen spatial method.
 
         Returns
         -------

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -141,6 +141,26 @@ class SpatialMethod:
         """
         raise NotImplementedError
 
+    def mass_matrix(self, symbol, boundary_conditions):
+        """
+        Calculates the mass matrix for a spatial method.
+
+        Parameters
+        ----------
+        symbol: :class:`pybamm.Variable`
+            The variable corresponding to the equation for which we are
+            calculating the mass matrix.
+        boundary_conditions : dict
+            The boundary conditions of the model
+            ({symbol.id: {"left": left bc, "right": right bc}})
+
+        Returns
+        -------
+        :class:`pybamm.Matrix`
+            The (sparse) mass matrix for the spatial method.
+        """
+        raise NotImplementedError
+
     # We could possibly move the following outside of SpatialMethod
     # depending on the requirements of the FiniteVolume
 

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -46,6 +46,13 @@ class SpatialMethodForTesting(pybamm.SpatialMethod):
         divergence_matrix = pybamm.Matrix(np.eye(n))
         return divergence_matrix @ discretised_symbol
 
+    def mass_matrix(self, symbol, boundary_conditions):
+        n = 0
+        for domain in symbol.domain:
+            n += self.mesh[domain].npts
+        mass_matrix = pybamm.Matrix(np.eye(n))
+        return mass_matrix
+
     def compute_diffusivity(self, symbol):
         return symbol
 

--- a/tests/test_spatial_methods/test_finite_volume.py
+++ b/tests/test_spatial_methods/test_finite_volume.py
@@ -1029,9 +1029,9 @@ class TestFiniteVolume(unittest.TestCase):
             r_disc.evaluate(), 3 * disc.mesh["negative particle"][0].nodes
         )
 
-    def test_mass_matrix_Dirichlet_bcs(self):
+    def test_mass_matrix_shape(self):
         """
-        Test mass matrix with Dirichlet boundary conditions
+        Test mass matrix shape
         """
         # one equation
         whole_cell = ["negative electrode", "separator", "positive electrode"]
@@ -1057,41 +1057,9 @@ class TestFiniteVolume(unittest.TestCase):
         mass = np.eye(combined_submesh[0].npts)
         np.testing.assert_array_equal(mass, model.mass_matrix.entries.toarray())
 
-    def test_mass_matrix_Neumann_bcs(self):
-        """
-        Test mass matrix with Neumann boundary conditions
-        """
-        # one equation
-        whole_cell = ["negative electrode", "separator", "positive electrode"]
-        c = pybamm.Variable("c", domain=whole_cell)
-        N = pybamm.grad(c)
-        model = pybamm.BaseModel()
-        model.rhs = {c: pybamm.div(N)}
-        model.initial_conditions = {c: pybamm.Scalar(0)}
-        model.boundary_conditions = {
-            N: {"left": pybamm.Scalar(0), "right": pybamm.Scalar(0)}
-        }
-        model.variables = {"c": c, "N": N}
-
-        # create discretisation
-        mesh = get_mesh_for_testing()
-        spatial_methods = {"macroscale": pybamm.FiniteVolume}
-        disc = pybamm.Discretisation(mesh, spatial_methods)
-
-        combined_submesh = mesh.combine_submeshes(*whole_cell)
-        mesh.add_ghost_meshes()
-        disc.mesh.add_ghost_meshes()
-
-        disc.process_model(model)
-
-        # mass matrix
-        mass = np.eye(combined_submesh[0].npts)
-        np.testing.assert_array_equal(mass, model.mass_matrix.entries.toarray())
-
     def test_p2d_mass_matrix_shape(self):
         """
-        Test grad and div with Dirichlet boundary conditions (applied by grad on var)
-        in the pseudo 2-dimensional case
+        Test mass matrix shape in the pseudo 2-dimensional case
         """
         c = pybamm.Variable("c", domain=["negative particle"])
         N = pybamm.grad(c)

--- a/tests/test_spatial_methods/test_spatial_methods.py
+++ b/tests/test_spatial_methods/test_spatial_methods.py
@@ -24,6 +24,8 @@ class TestSpatialMethod(unittest.TestCase):
             spatial_method.surface_value(None)
         with self.assertRaises(NotImplementedError):
             spatial_method.compute_diffusivity()
+        with self.assertRaises(NotImplementedError):
+            spatial_method.mass_matrix(None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Adds `mass_matrix` attribute to model which is processed during discretisation to give the correct mass matrix for a given spatial method

Fixes #215 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
